### PR TITLE
Peek / Poke records check type equivalence for both data fields

### DIFF
--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -113,7 +113,7 @@ package object chiseltest {
         require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
         pokeBits(x, value.litValue)
       case (x: Record, value: Record) => {
-        require(DataMirror.checkTypeEquivalence(x, value), s"Record type mismatch")
+        require(DataMirror.checkTypeEquivalence(value, x) || DataMirror.checkTypeEquivalence(x, value), s"Record type mismatch")
         (x.elements.zip(value.elements)).foreach {
           case ((_, x), (_, value)) =>
             x.poke(value)
@@ -176,7 +176,7 @@ package object chiseltest {
         require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
         Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.fixedToString(x.binaryPoint)), stale)
       case (x: Record, value: Record) => {
-        require(DataMirror.checkTypeEquivalence(x, value), s"Record type mismatch")
+        require(DataMirror.checkTypeEquivalence(value, x) || DataMirror.checkTypeEquivalence(x, value), s"Record type mismatch")
         (x.elements.zip(value.elements)).foreach {
           case ((_, x), (_, value)) =>
             x.expectWithStale(value, message, stale)


### PR DESCRIPTION
Currently I have to write code similar to this

```scala
class AluInput(val size: Int) extends Bundle with RandBundle {
  val a = UInt(size.W)
  val b = UInt(size.W)
  val fn = UInt(2.W)

override def typeEquivalent(data: Data): Boolean = {
    data match {
      case _: (AluInput @ AluInputConstraint(size)) => true
      case _ => false
    }
  }
}

class AluInputTransaction(size: Int) extends AluInput(size) {

  def expectedResult(): AluOutput = {
      var result: BigInt = 0
      if (fn.litValue() == 0) {
        result = a.litValue() + b.litValue()
      } else if (fn.litValue() == 1) {
        result = a.litValue() - b.litValue()
      } else if (fn.litValue() == 2) {
        result = a.litValue() | b.litValue()
      } else {
        result = a.litValue() & b.litValue()
      }
      new AluOutput(8).Lit(_.result -> result.U)
  }
}
```

It would be nice if all the logic would be moved from the `AluInput` bundle to `AluInputTransaction` and overriding the `typeEquivalent` method only in `AluInputTransaction`

```scala
class AluInput(val size: Int) extends Bundle with RandBundle {
  val a = UInt(size.W)
  val b = UInt(size.W)
  val fn = UInt(2.W)

}

class AluInputTransaction(size: Int) extends AluInput(size) {

override def typeEquivalent(data: Data): Boolean = {
    data match {
      case _: (AluInput @ AluInputConstraint(size)) => true
      case _ => false
    }
  }

  def expectedResult(): AluOutput = {
      var result: BigInt = 0
      if (fn.litValue() == 0) {
        result = a.litValue() + b.litValue()
      } else if (fn.litValue() == 1) {
        result = a.litValue() - b.litValue()
      } else if (fn.litValue() == 2) {
        result = a.litValue() | b.litValue()
      } else {
        result = a.litValue() & b.litValue()
      }
      new AluOutput(8).Lit(_.result -> result.U)
  }
}
```
So I propose the changes in `peek` and `poke` methods for the `Record` type. 

