### PR TITLE
formal: add verify method to RawTester

### DIFF
--- a/src/main/scala/chiseltest/RawTester.scala
+++ b/src/main/scala/chiseltest/RawTester.scala
@@ -5,13 +5,14 @@ package chiseltest
 import chiseltest.internal._
 import chiseltest.experimental.sanitizeFileName
 import chisel3.Module
+import chiseltest.formal.Formal
 import chiseltest.internal.TestEnvInterface.addDefaultTargetDir
 import firrtl.AnnotationSeq
 
 /** Used to run simple tests that do not require a scalatest environment in order to run
   * @param testName This will be used to generate a working directory in ./test_run_dir
   */
-private class RawTester(testName: String) extends TestEnvInterface {
+private class RawTester(testName: String) extends TestEnvInterface with HasTestName with Formal {
   // Provide test fixture data as part of 'global' context during test runs
   val topFileName = Some(testName)
 
@@ -25,6 +26,8 @@ private class RawTester(testName: String) extends TestEnvInterface {
     val newAnnos = addDefaultTargetDir(sanitizeFileName(testName), annotationSeq)
     runTest(defaults.createDefaultTester(() => dutGen, newAnnos))(testFn)
   }
+
+  override def getTestName = testName
 }
 
 /** This is a simple tester that does not require that it be within the scope of a scalatest
@@ -54,5 +57,25 @@ object RawTester {
 
     val tester = new RawTester(testName)
     tester.test(dutGen, annotationSeq)(testFn)
+  }
+
+  /** Run a formal check.
+    * General use looks like
+    * {{{
+    *   import chiseltest.formal._
+    *   verify(new FailAfterModule(2), Seq(BoundedCheck(kMax = 2)), "FailAfterModule Test")
+    * }}}
+    *
+    * @note every test should use a different name, it, suitably sanitized, is used as the subdirectory in the
+    *       test_run_dir directory
+    * @param dutGen The generator of the device under tests
+    * @param annos  Annotations including the verification command to be executed.
+    * @param testName Optional test name that will be converted into a test directory name.
+    * @tparam T        The type of device, derived from dutGen
+    */
+  def verify[T <: Module](dutGen: => T, annos: AnnotationSeq, testName: String = ""): Unit = {
+    def randomTestName = s"chisel_test_${System.currentTimeMillis()}"
+    val tester = new RawTester(if (testName.trim.isEmpty) randomTestName else testName)
+    tester.verify(dutGen, annos)
   }
 }

--- a/src/test/scala/chiseltest/formal/BasicBoundedCheckTests.scala
+++ b/src/test/scala/chiseltest/formal/BasicBoundedCheckTests.scala
@@ -39,6 +39,16 @@ class BasicBoundedCheckTests extends AnyFlatSpec with ChiselScalatestTester with
   it should "verify DanielModuleWithGoodAssertion" taggedAs FormalTag in {
     verify(new DanielModuleWithGoodAssertion, Seq(BoundedCheck(kMax = 4)))
   }
+
+  it should "support simple bmc with the RawTester" taggedAs FormalTag in {
+    RawTester.verify(new FailAfterModule(2), Seq(BoundedCheck(kMax = 1)))
+  }
+
+  it should "support simple bmc with a failing check with the RawTester" taggedAs FormalTag in {
+    assertThrows[FailedBoundedCheckException] {
+      RawTester.verify(new FailAfterModule(2), Seq(BoundedCheck(kMax = 2)))
+    }
+  }
 }
 
 class AssumeAssertTestModule extends Module {


### PR DESCRIPTION
This is needed in order to do formal verification in a jupyter notebook environment like the bootcamp.