### PR TITLE
add experimental NoThreadingAnnotation as a performance hint

### DIFF
--- a/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
+++ b/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
@@ -1,0 +1,142 @@
+package chiseltest.internal
+
+import chisel3.{Clock, Data, Module}
+import chiseltest.{ChiselAssertionError, ClockResolutionException, Region, StopException, TimeoutException}
+import chiseltest.coverage.TestCoverage
+import chiseltest.simulator.{SimulatorContext, StepInterrupted, StepOk}
+import firrtl.AnnotationSeq
+import scala.collection.mutable
+
+/** Chiseltest backend that does not support fork or timescope but is generally faster since it
+  * does not need to launch any Java threads.
+  */
+class SingleThreadBackend[T <: Module](
+  val dut:                T,
+  val dataNames:          Map[Data, String],
+  val combinationalPaths: Map[Data, Set[Data]],
+  tester:                 SimulatorContext,
+  coverageAnnotations:    AnnotationSeq)
+    extends BackendInstance[T] {
+
+  private def resolveName(signal: Data): String = { // TODO: unify w/ dataNames?
+    dataNames.getOrElse(signal, signal.toString)
+  }
+
+  // Circuit introspection functionality
+  override def getSourceClocks(signal: Data): Set[Clock] = {
+    throw new ClockResolutionException("ICR not available on chisel-testers2 / firrtl master")
+  }
+
+  override def getSinkClocks(signal: Data): Set[Clock] = {
+    throw new ClockResolutionException("ICR not available on chisel-testers2 / firrtl master")
+  }
+
+  override def pokeClock(signal: Clock, value: Boolean): Unit = {
+    throw new NotImplementedError("Poking clocks is currently no supported!")
+  }
+
+  override def peekClock(signal: Clock): Boolean = {
+    val a = tester.peek(dataNames(signal))
+    a > 0
+  }
+
+  private val previousPokes = mutable.HashMap[String, BigInt]()
+  override def pokeBits(signal: Data, value: BigInt): Unit = {
+    val name = dataNames(signal)
+    previousPokes.get(name) match {
+      case Some(oldValue) if oldValue == value => // ignore
+      case _ =>
+        tester.poke(name, value)
+        idleCycles = 0
+        previousPokes(name) = value
+    }
+  }
+
+  override def peekBits(signal: Data, stale: Boolean): BigInt = {
+    require(!stale, "Stale peek not yet implemented")
+    val a = tester.peek(dataNames(signal))
+    a
+  }
+
+  override def expectBits(
+    signal:  Data,
+    value:   BigInt,
+    message: Option[String],
+    decode:  Option[BigInt => String],
+    stale:   Boolean
+  ): Unit = {
+    require(!stale, "Stale peek not yet implemented")
+    Context().env.testerExpect(value, peekBits(signal, stale), resolveName(signal), message, decode)
+  }
+
+  override def doTimescope(contents: () => Unit): Unit = {
+    throw new NotImplementedError("This backend does not support timescopes!")
+  }
+
+  override def doFork(runnable: () => Unit, name: Option[String], region: Option[Region]): Nothing = {
+    throw new NotImplementedError("This backend does not support threads!")
+  }
+
+  override def doJoin(threads: Seq[AbstractTesterThread], stepAfter: Option[Clock]): Unit = {
+    throw new NotImplementedError("This backend does not support threads!")
+  }
+
+  private var timeout = 1000
+  private var idleCycles = 0
+
+  override def step(signal: Clock, cycles: Int): Unit = {
+    require(signal == dut.clock)
+    // throw any available exceptions before stepping
+    Context().env.checkpoint()
+    val delta = if (timeout == 0) cycles else Seq(cycles, timeout - idleCycles).min
+    tester.step(delta) match {
+      case StepOk =>
+        // update and check timeout
+        idleCycles += delta
+        if (timeout > 0 && idleCycles == timeout) {
+          throw new TimeoutException(s"timeout on $signal at $timeout idle cycles")
+        }
+      case StepInterrupted(_, true, _) =>
+        val msg = s"An assertion in ${dut.name} failed.\n" +
+          "Please consult the standard output for more details."
+        throw new ChiselAssertionError(msg)
+      case StepInterrupted(_, false, _) =>
+        val msg = s"A stop() statement was triggered in ${dut.name}."
+        throw new StopException(msg)
+    }
+  }
+
+  override def setTimeout(signal: Clock, cycles: Int): Unit = {
+    require(signal == dut.clock, "timeout currently only supports master clock")
+    require(cycles >= 0, s"Negative timeout $cycles is not supported! Use 0 to disable the timeout.")
+    timeout = cycles
+    idleCycles = 0
+  }
+
+  override def run(testFn: T => Unit): AnnotationSeq = {
+    try {
+      // default reset
+      tester.poke("reset", 1)
+      tester.step(1)
+      tester.poke("reset", 0)
+
+      // execute use code
+      testFn(dut)
+
+      // throw any exceptions that might be left over
+      Context().env.checkpoint()
+    } finally {
+      tester.finish() // needed to dump VCDs + terminate any external process
+    }
+
+    if (tester.sim.supportsCoverage) {
+      generateTestCoverageAnnotation() +: coverageAnnotations
+    } else { Seq() }
+  }
+
+  /** Generates an annotation containing the map from coverage point names to coverage counts. */
+  private def generateTestCoverageAnnotation(): TestCoverage = {
+    TestCoverage(tester.getCoverage())
+  }
+
+}

--- a/src/main/scala/chiseltest/internal/Testers2.scala
+++ b/src/main/scala/chiseltest/internal/Testers2.scala
@@ -8,10 +8,20 @@ import firrtl.annotations.NoTargetAnnotation
 
 import scala.util.DynamicVariable
 
+/** Hint for the backend to try and re-use a compiled simulation from a prior run.
+  * @warn this is an experimental option and might be removed in the next release without warning
+  */
 case object CachingAnnotation extends NoTargetAnnotation
 
-/** use this option to have all simulator interactions printed to stdout */
+/** Use this option to have all simulator interactions printed to stdout.
+  * @warn this is an experimental option and might be removed in the next release without warning
+  */
 case object PrintPeekPoke extends NoTargetAnnotation
+
+/** This option may speed up your test, but any use of `fork` or `timescope` will fail.
+  * @warn this is an experimental option and might be removed in the next release without warning
+  */
+case object NoThreadingAnnotation extends NoTargetAnnotation
 
 object Context {
   class Instance(val backend: BackendInterface, val env: TestEnvInterface) {}

--- a/src/test/scala/chiseltest/benchmark/ChiseltestBenchmark.scala
+++ b/src/test/scala/chiseltest/benchmark/ChiseltestBenchmark.scala
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.benchmark
+
+import chiseltest._
+import chisel3._
+import chiseltest.internal.NoThreadingAnnotation
+import chiseltest.simulator.SimulatorAnnotation
+import chiseltest.simulator.benchmark.DecoupledGcd
+import firrtl.options.TargetDirAnnotation
+import treadle.chronometry.Timer
+
+object ChiseltestBenchmark extends App {
+  private def computeGcd(a: BigInt, b: BigInt): BigInt = a.gcd(b)
+
+  private def runTest(dut: DecoupledGcd, testValues: Iterable[(BigInt, BigInt, BigInt)]): Long = {
+    var cycles = 0L
+    dut.reset.poke(true.B)
+    dut.clock.step(2)
+    cycles += 2
+    dut.reset.poke(false.B)
+
+    dut.output.ready.poke(true.B)
+    for((i, j, expected) <- testValues) {
+      dut.input.bits.value1.poke(i.U)
+      dut.input.bits.value2.poke(j.U)
+      dut.input.valid.poke(true.B)
+      dut.clock.step(1)
+      cycles += 1
+
+      while(!dut.output.valid.peek().litToBoolean) {
+        dut.clock.step(1)
+        cycles += 1
+      }
+      dut.output.bits.gcd.expect(expected.U)
+      dut.output.valid.expect(true.B)
+    }
+
+    cycles
+  }
+
+  // select and load simulator
+  val sim: SimulatorAnnotation = args.headOption match {
+    case None => VerilatorBackendAnnotation
+    case Some(name) => name.toLowerCase match {
+      case "verilator" => VerilatorBackendAnnotation
+      case "treadle" => TreadleBackendAnnotation
+      case "iverilog" => IcarusBackendAnnotation
+      case "vcd" => VcsBackendAnnotation
+      case other => throw new RuntimeException(s"Unknown simulator option: $other")
+    }
+  }
+  val simName = sim.getSimulator.name
+
+  val targetDir = TargetDirAnnotation("test_run_dir/gcd_benchmark_chiseltest_and_" + simName)
+  val annos = Seq(targetDir, sim, NoThreadingAnnotation)
+
+  val repetitions = 6
+  val numMax = 200
+  val testValues = for {x <- 2 to numMax; y <- 2 to numMax} yield (BigInt(x), BigInt(y), computeGcd(x, y))
+  val t = new Timer
+  var cycles = 0L
+
+  RawTester.test(new DecoupledGcd(bitWidth = 60), annos) { dut =>
+    (0 until repetitions).foreach { _ =>
+      t("sim-gcd-chiseltest-" + simName) {
+        cycles += runTest(dut, testValues)
+      }
+    }
+  }
+
+  println(t.report())
+  println(s"$cycles cycles")
+}

--- a/src/test/scala/chiseltest/tests/NoThreadingTests.scala
+++ b/src/test/scala/chiseltest/tests/NoThreadingTests.scala
@@ -1,0 +1,174 @@
+package chiseltest.tests
+
+import chisel3._
+import chisel3.experimental.BundleLiterals._
+import chiseltest._
+import chiseltest.internal.NoThreadingAnnotation
+import org.scalatest.exceptions
+import org.scalatest.flatspec.AnyFlatSpec
+
+class NoThreadingTests extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "NoThreadingAnnotation"
+
+  val annos = Seq(NoThreadingAnnotation)
+
+  it should "assert (with treadle)" in {
+    assertThrows[ChiselAssertionError] {
+      test(new AssertTestBench()).withAnnotations(annos) { dut =>
+        dut.io.enable.poke(true.B)
+        dut.clock.step(1)
+      }
+    }
+  }
+
+  it should "fail on poking outputs" in {
+    assertThrows[UnpokeableException] {
+      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+        c.out.poke(0.U)
+      }
+    }
+  }
+
+  it should "fail on expect mismatch" in {
+    assertThrows[exceptions.TestFailedException] {
+      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+        c.out.expect(0.U)
+      }
+    }
+  }
+
+  it should "fail on record expect mismatch" in {
+    val typ = new CustomBundle("foo" -> UInt(32.W), "bar" -> UInt(32.W))
+    assertThrows[exceptions.TestFailedException] {
+      test(new PassthroughModule(typ)).withAnnotations(annos) { c =>
+        c.in.pokePartial(typ.Lit(
+          _.elements("foo") -> 4.U
+        ))
+        c.out.expect(typ.Lit(
+          _.elements("foo") -> 4.U,
+          _.elements("bar") -> 5.U
+        ))
+      }
+    }
+  }
+
+  it should "fail on partial expect mismatch" in {
+    val typ = new CustomBundle("foo" -> UInt(32.W), "bar" -> UInt(32.W))
+    assertThrows[exceptions.TestFailedException] {
+      test(new PassthroughModule(typ)).withAnnotations(annos) { c =>
+        c.in.poke(typ.Lit(
+          _.elements("foo") -> 4.U,
+          _.elements("bar") -> 5.U
+        ))
+        c.out.expectPartial(typ.Lit(
+          _.elements("foo") -> 5.U
+        ))
+      }
+    }
+  }
+
+  it should "fail with user-defined message" in {
+    val e = intercept[exceptions.TestFailedException] {
+      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+        c.out.expect(0.U, "user-defined failure message =(")
+      }
+    }
+    assert(e.getMessage.contains("user-defined failure message =("))
+  }
+
+  class PropagationTestException extends Exception
+
+  it should "propagate exceptions in the main test thread" in {
+    assertThrows[PropagationTestException] {
+      test(new StaticModule(false.B)).withAnnotations(annos) { _ =>
+        throw new PropagationTestException
+      }
+    }
+  }
+
+  it should "display both decimal and hex for ints" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+        c.out.expect(0.U)
+      }
+    }
+    assert(exc.getMessage.contains("42 (0x2a)"))
+    assert(exc.getMessage.contains("expected=0 (0x0)"))
+  }
+
+  it should "fail on default timeout at 1000 cycles" in {
+    test(new StaticModule(0.U)).withAnnotations(annos) { c =>
+      c.clock.step(999)
+    }
+    assertThrows[TimeoutException] {
+      test(new StaticModule(0.U)).withAnnotations(annos) { c =>
+        c.clock.step(1000)
+      }
+    }
+  }
+
+  it should "disable timeout when set to zero" in {
+    test(new StaticModule(0.U)).withAnnotations(annos) { c =>
+      c.clock.setTimeout(0)
+      c.clock.step(1000)
+    }
+  }
+
+
+  it should "have a configurable timeout" in {
+    test(new StaticModule(0.U)).withAnnotations(annos) { c =>
+      c.clock.setTimeout(4)
+      c.clock.step(3)
+    }
+    assertThrows[TimeoutException] {
+      test(new StaticModule(0.U)).withAnnotations(annos) { c =>
+        c.clock.setTimeout(4)
+        c.clock.step(4)
+      }
+    }
+  }
+
+  it should "reset the timeout counter on a poke" in {
+    test(new PassthroughModule(UInt(8.W))).withAnnotations(annos) { c =>
+      c.clock.setTimeout(4)
+
+      c.in.poke(0.U)
+      c.clock.step(3)
+      c.in.poke(1.U)
+      c.clock.step(3)
+      c.in.poke(2.U)
+      c.clock.step(3)
+      c.in.poke(3.U)
+      c.clock.step(3)
+      c.in.poke(2.U)
+      c.clock.step(3)
+    }
+    assertThrows[TimeoutException] {
+      test(new PassthroughModule(UInt(8.W))).withAnnotations(annos) { c =>
+        c.clock.setTimeout(4)
+
+        c.in.poke(0.U)
+        c.clock.step(3)
+        c.in.poke(1.U)
+        c.clock.step(3)
+        c.in.poke(2.U)
+        c.clock.step(4)
+        c.clock.step(1)  // don't let the timescope expire
+      }
+    }
+  }
+
+  it should "ignore nop pokes" in {
+    assertThrows[TimeoutException] {
+      test(new PassthroughModule(UInt(8.W))).withAnnotations(annos) { c =>
+        c.clock.setTimeout(4)
+
+        c.in.poke(0.U)
+        c.clock.step(3)
+        c.in.poke(0.U)
+        c.clock.step(1)
+        c.clock.step(1)  // don't let the timescope expire
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `chiseltest.internal.NoThreadingAnnotation` which can be used to significantly speed up tests that do not use `fork` or `timescope`.

On the GCD benchmark with verilator as a backend I observe a speedup of > 20x going from ~301s to ~14s.

I have tried to take into account all that we have discussed on the previous PRs (https://github.com/ucb-bar/chisel-testers2/pull/365, https://github.com/ucb-bar/chisel-testers2/pull/371). This new implementation is _opt-in_ and modifies almost no existing code. I also added a test suite to make sure the non-threading related features work as expected.

I would like to propose this PR for inclusion in the 0.5 release, unless someone manages to implement the nicer solution of optimizing the existing threaded backend before the deadline.