### PR TITLE
Handle vl_fatal in Verilator

### DIFF
--- a/src/main/scala/chiseltest/simulator/jna/JNASimulatorContext.scala
+++ b/src/main/scala/chiseltest/simulator/jna/JNASimulatorContext.scala
@@ -107,6 +107,10 @@ private[chiseltest] class JNASimulatorContext(
     val status = (r >> 32) & 3
     if (status == 0) {
       StepOk
+    } else if (status == 3) {
+      val msg = "The simulator has encountered an unrecoverable error.\n" +
+        "Please consult the standard output and error for more details."
+      throw new RuntimeException(msg)
     } else {
       val isFailure = status != 1
       val after = r & 0xffffffffL

--- a/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala
@@ -220,10 +220,11 @@ static sim_state* create_sim_state() {
                          |}
                          |
                          |
+                         |static bool encounteredFatal = false;
                          |void vl_fatal(const char* filename, int linenum, const char* hier, const char* msg) {
-                         |  std::cerr << "unexpected call to vl_fatal, please file an issue" << std::endl;
-                         |  std::cerr << "fatal! (" << filename << ", " << linenum << ", " << hier << ")" << std::endl;
+                         |  std::cerr << "fatal! (" << filename << ", " << linenum << ", " << hier << ", " << msg << ")" << std::endl;
                          |  $verilatorRunFlushCallback
+                         |  encounteredFatal = true;
                          |}
                          |
                          |
@@ -273,6 +274,9 @@ static sim_state* create_sim_state() {
                          |      // vl_finish is called by verilator when a finish command is executed (stop(0))
                          |      encounteredFinish = false;
                          |      return 1;
+                         |    } else if(encounteredFatal) {
+                         |      encounteredFatal = false;
+                         |      return 3;
                          |    }
                          |    return 0;
                          |}


### PR DESCRIPTION
Print the fatal message and return non-zero from the simulation.

Fixes https://github.com/ucb-bar/chisel-testers2/issues/422