### PR TITLE
Add peek<Type> as peek method that returns Scala types

### DIFF
--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -214,7 +214,7 @@ package object chiseltest {
         }
     }
 
-    protected def peekWithStaleInt(stale: Boolean): BigInt = x match {
+    protected def peekWithStaleBigInt(stale: Boolean): BigInt = x match {
       case (x: UInt) => Context().backend.peekBits(x, stale)
       case (x: SInt) => Context().backend.peekBits(x, stale)
     }
@@ -229,13 +229,13 @@ package object chiseltest {
     protected def peekWithStaleVecInt(stale: Boolean): Seq[BigInt] = x match {
       case (x: Vec[UInt]) => {
         val elementValueFns = x.getElements.map { case elt: Data =>
-          elt.peekWithStaleInt(stale)
+          elt.peekWithStaleBigInt(stale)
         }
         Seq(elementValueFns: _*)
       }
       case (x: Vec[SInt]) => {
         val elementValueFns = x.getElements.map { case elt: Data =>
-          elt.peekWithStaleInt(stale)
+          elt.peekWithStaleBigInt(stale)
         }
         Seq(elementValueFns: _*)
       }
@@ -250,12 +250,13 @@ package object chiseltest {
       }
     }
 
-    def peek():           T = peekWithStale(false)
-    def peekBool():       Boolean = peekWithStaleBool(false)
-    def peekInt():        BigInt = peekWithStaleInt(false)
-    def peekDecimal():    BigDecimal = peekWithStaleDec(false)
-    def peekVectorInt():  Seq[BigInt] = peekWithStaleVecInt(false)
-    def peekVectorBool(): Seq[Boolean] = peekWithStaleVecBool(false)
+    def peek():          T = peekWithStale(false)
+    def peekBool():      Boolean = peekWithStaleBool(false)
+    def peekBigInt():    BigInt = peekWithStaleBigInt(false)
+    def peekInt():       Integer = peekWithStaleBigInt(false).toInt
+    def peekDecimal():   BigDecimal = peekWithStaleDec(false)
+    def peekVecBigInt(): Seq[BigInt] = peekWithStaleVecInt(false)
+    def peekVecBool():   Seq[Boolean] = peekWithStaleVecBool(false)
 
     protected def expectWithStale(value: T, message: Option[String], stale: Boolean): Unit = (x, value) match {
       case (x: Bool, value: Bool) =>

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -250,13 +250,13 @@ package object chiseltest {
       }
     }
 
-    def peek():          T = peekWithStale(false)
-    def peekBool():      Boolean = peekWithStaleBool(false)
-    def peekBigInt():    BigInt = peekWithStaleBigInt(false)
-    def peekInt():       Integer = peekWithStaleBigInt(false).toInt
-    def peekDecimal():   BigDecimal = peekWithStaleDec(false)
-    def peekVecBigInt(): Seq[BigInt] = peekWithStaleVecInt(false)
-    def peekVecBool():   Seq[Boolean] = peekWithStaleVecBool(false)
+    def peek():           T = peekWithStale(false)
+    def peekBoolean():    Boolean = peekWithStaleBool(false)
+    def peekBigInt():     BigInt = peekWithStaleBigInt(false)
+    def peekInteger():    Integer = peekWithStaleBigInt(false).toInt
+    def peekBigDecimal(): BigDecimal = peekWithStaleDec(false)
+    def peekVecBigInt():  Seq[BigInt] = peekWithStaleVecInt(false)
+    def peekVecBoolean(): Seq[Boolean] = peekWithStaleVecBool(false)
 
     protected def expectWithStale(value: T, message: Option[String], stale: Boolean): Unit = (x, value) match {
       case (x: Bool, value: Bool) =>

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -219,43 +219,9 @@ package object chiseltest {
       case (x: SInt) => Context().backend.peekBits(x, stale)
     }
 
-    protected def peekWithStaleDec(stale: Boolean): BigDecimal = x match {
-      case (x: FixedPoint) => {
-        val multiplier = BigDecimal(2).pow(x.binaryPoint.get)
-        BigDecimal(Context().backend.peekBits(x, stale)) / multiplier
-      }
-    }
-
-    protected def peekWithStaleVecInt(stale: Boolean): Seq[BigInt] = x match {
-      case (x: Vec[UInt]) => {
-        val elementValueFns = x.getElements.map { case elt: Data =>
-          elt.peekWithStaleBigInt(stale)
-        }
-        Seq(elementValueFns: _*)
-      }
-      case (x: Vec[SInt]) => {
-        val elementValueFns = x.getElements.map { case elt: Data =>
-          elt.peekWithStaleBigInt(stale)
-        }
-        Seq(elementValueFns: _*)
-      }
-    }
-
-    protected def peekWithStaleVecBool(stale: Boolean): Seq[Boolean] = x match {
-      case (x: Vec[Bool]) => {
-        val elementValueFns = x.getElements.map { case elt: Data =>
-          elt.peekWithStaleBool(stale)
-        }
-        Seq(elementValueFns: _*)
-      }
-    }
-
     def peek():        T = peekWithStale(false)
-    def peekBool():    Boolean = peekWithStaleBool(false)
+    def peekBoolean(): Boolean = peekWithStaleBool(false)
     def peekInt():     BigInt = peekWithStaleBigInt(false)
-    def peekDec():     BigDecimal = peekWithStaleDec(false)
-    def peekVecInt():  Seq[BigInt] = peekWithStaleVecInt(false)
-    def peekVecBool(): Seq[Boolean] = peekWithStaleVecBool(false)
 
     protected def expectWithStale(value: T, message: Option[String], stale: Boolean): Unit = (x, value) match {
       case (x: Bool, value: Bool) =>

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -205,7 +205,7 @@ package object chiseltest {
       case x => throw new LiteralTypeException(s"don't know how to peek $x")
     }
 
-    protected def peekWithStaleLit(stale: Boolean): Any = x match {
+    protected def peekWithStaleNative(stale: Boolean): Any = x match {
       case (x: Bool) =>
         Context().backend.peekBits(x, stale) match {
           case x: BigInt if x == 0 => false
@@ -225,7 +225,7 @@ package object chiseltest {
       }
       case (x: Vec[_]) =>
         val elementValueFns = x.getElements.map { case elt: Data =>
-          elt.peekWithStaleLit(stale)
+          elt.peekWithStaleNative(stale)
         }
         Seq(elementValueFns: _*)
       case (x: EnumType) => {
@@ -236,7 +236,7 @@ package object chiseltest {
 
     def peek(): T = peekWithStale(false)
 
-    def litPeek(): Any = peekWithStaleLit(false)
+    def asNative(): Any = peekWithStaleNative(false)
 
     protected def expectWithStale(value: T, message: Option[String], stale: Boolean): Unit = (x, value) match {
       case (x: Bool, value: Bool) =>

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -250,13 +250,12 @@ package object chiseltest {
       }
     }
 
-    def peek():           T = peekWithStale(false)
-    def peekBoolean():    Boolean = peekWithStaleBool(false)
-    def peekBigInt():     BigInt = peekWithStaleBigInt(false)
-    def peekInteger():    Integer = peekWithStaleBigInt(false).toInt
-    def peekBigDecimal(): BigDecimal = peekWithStaleDec(false)
-    def peekVecBigInt():  Seq[BigInt] = peekWithStaleVecInt(false)
-    def peekVecBoolean(): Seq[Boolean] = peekWithStaleVecBool(false)
+    def peek():        T = peekWithStale(false)
+    def peekBool():    Boolean = peekWithStaleBool(false)
+    def peekInt():     BigInt = peekWithStaleBigInt(false)
+    def peekDec():     BigDecimal = peekWithStaleDec(false)
+    def peekVecInt():  Seq[BigInt] = peekWithStaleVecInt(false)
+    def peekVecBool(): Seq[Boolean] = peekWithStaleVecBool(false)
 
     protected def expectWithStale(value: T, message: Option[String], stale: Boolean): Unit = (x, value) match {
       case (x: Bool, value: Bool) =>

--- a/src/test/scala/chiseltest/tests/LiteralTest.scala
+++ b/src/test/scala/chiseltest/tests/LiteralTest.scala
@@ -29,72 +29,58 @@ class LiteralVecB extends Module {
 class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
-  it should "test literal UInt" in {
+  it should "test literal UInt as BigInt" in {
     test(new StaticModule(42.U)) { c =>
-      c.out.litPeek() should be (42)
-      c.out.litPeek() should be (BigInt(42))
-      c.out.litPeek() should be (42.toLong)
-      assert(c.out.litPeek() == 42)
+      c.out.peekInt() should be (42)
+      c.out.peekInt() should be (BigInt(42))
+      c.out.peekInt() should be (42.toLong)
+      assert(c.out.peekInt() == 42)
     }
   }
 
-  it should "test literal SInt" in {
+  it should "test literal SInt as BigInt" in {
     test(new StaticModule(-42.S)) { c =>
-      c.out.litPeek() should be (-42)
-      c.out.litPeek() should be (BigInt(-42))
-      c.out.litPeek() should be (-42.toLong)
-      assert(c.out.litPeek() == -42)
+      c.out.peekInt() should be (-42)
+      c.out.peekInt() should be (BigInt(-42))
+      c.out.peekInt() should be (-42.toLong)
+      assert(c.out.peekInt() == -42)
     }
   }
 
-  it should "test literal FixedPoint" in {
+  it should "test literal FixedPoint as BigDecimal" in {
     test(new StaticModule(10.F(2.BP))) { c =>
-      c.out.litPeek() should be (BigDecimal(10))
+      c.out.peekDecimal() should be (BigDecimal(10))
     }
   }
 
-  it should "test literal Boolean" in {
+  it should "test literal Bool as Boolean" in {
     test(new StaticModule(true.B)) { c =>
-      // Multiple ways to check the literal value
-      // c.out.litPeek() should be (true) // <-- scalatest doesn't like this one
-      c.out.litPeek() should equal (true)
-      c.out.litPeek() should === (true)
-      c.out.litPeek() shouldBe true
-      assert(c.out.litPeek() == true)
+      // Multiple ways to check the value
+      c.out.peekBool() should be (true)
+      assert(c.out.peekBool() == true)
     }
     test(new StaticModule(false.B)) { c =>
-      // Multiple ways to check the literal value
-      // c.out.litPeek() should be (false) // <-- scalatest doesn't like this one
-      c.out.litPeek() should equal (false)
-      c.out.litPeek() should === (false)
-      c.out.litPeek() shouldBe false
-      assert(c.out.litPeek() == false)
+      // Multiple ways to check the value
+      c.out.peekBool() should be (false)
+      assert(c.out.peekBool() == false)
     }
   }
 
-  it should "test literal Vector of UInt" in {
+  it should "test literal Vector of UInt as Seq[BigInt]" in {
     test(new LiteralVecU) { c =>
-      c.out.litPeek() should be (Seq(1, 2, 4, 8))
+      c.out.peekVectorInt() should be (Seq(1, 2, 4, 8))
     }
   }
 
-  it should "test literal Vector of SInt" in {
+  it should "test literal Vector of SInt as Seq[BigInt]" in {
     test(new LiteralVecS) { c =>
-      c.out.litPeek() should be (Seq(1, -2, 4, -8))
+      c.out.peekVectorInt() should be (Seq(1, -2, 4, -8))
     }
   }
 
-  it should "test literal Vector of Bool" in {
+  it should "test literal Vector of Bool as Seq[Boolean]" in {
     test(new LiteralVecB) { c =>
-      c.out.litPeek() should be (Seq(true, false, true, false))
-    }
-  }
-
-  it should "test literal Interval thrown exception" in {
-    test(new StaticModule(1.I)) { c =>
-      val ex = intercept[LiteralTypeException] {
-        c.out.litPeek()
-      }
+      c.out.peekVectorBool() should be (Seq(true, false, true, false))
     }
   }
 

--- a/src/test/scala/chiseltest/tests/LiteralTest.scala
+++ b/src/test/scala/chiseltest/tests/LiteralTest.scala
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.tests
+
+import org.scalatest._
+
+import chisel3._
+import chisel3.experimental.BundleLiterals._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LiteralVecU extends Module {
+  val out   = IO(Output(Vec(4, UInt(8.W))))
+  val v = VecInit(1.U, 2.U, 4.U, 8.U)
+  out := v
+}
+class LiteralVecS extends Module {
+  val out   = IO(Output(Vec(4, SInt(8.W))))
+  val v = VecInit(1.S, -2.S, 4.S, -8.S)
+  out := v
+}
+class LiteralVecB extends Module {
+  val out   = IO(Output(Vec(4, Bool())))
+  val v = VecInit(true.B, false.B, true.B, false.B)
+  out := v
+}
+
+class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Testers2"
+
+  it should "test literal UInt" in {
+    test(new StaticModule(42.U)) { c =>
+      c.out.litPeek() should be (42)
+      c.out.litPeek() should be (BigInt(42))
+      c.out.litPeek() should be (42.toLong)
+      assert(c.out.litPeek() == 42)
+    }
+  }
+
+  it should "test literal SInt" in {
+    test(new StaticModule(-42.S)) { c =>
+      c.out.litPeek() should be (-42)
+      c.out.litPeek() should be (BigInt(-42))
+      c.out.litPeek() should be (-42.toLong)
+      assert(c.out.litPeek() == -42)
+    }
+  }
+
+  it should "test literal FixedPoint" in {
+    test(new StaticModule(10.F(2.BP))) { c =>
+      c.out.litPeek() should be (BigDecimal(10))
+    }
+  }
+
+  it should "test literal Boolean" in {
+    test(new StaticModule(true.B)) { c =>
+      c.out.litPeek() should equal (true)
+      // c.out.litPeek() should be (true) // <-- scalatest doesn't like this one
+      c.out.litPeek() should === (true)
+      c.out.litPeek() shouldBe true
+      assert(c.out.litPeek() == true)
+    }
+    test(new StaticModule(false.B)) { c =>
+      c.out.litPeek() should equal (false)
+      // c.out.litPeek() should be (false) // <-- scalatest doesn't like this one
+      c.out.litPeek() should === (false)
+      c.out.litPeek() shouldBe false
+      assert(c.out.litPeek() == false)
+    }
+  }
+
+  it should "test literal Vector of UInt" in {
+    test(new LiteralVecU) { c =>
+      c.out.litPeek() should be (Seq(1, 2, 4, 8))
+    }
+  }
+
+  it should "test literal Vector of SInt" in {
+    test(new LiteralVecS) { c =>
+      c.out.litPeek() should be (Seq(1, -2, 4, -8))
+    }
+  }
+
+  it should "test literal Vector of Bool" in {
+    test(new LiteralVecB) { c =>
+      c.out.litPeek() should be (Seq(true, false, true, false))
+    }
+  }
+
+  it should "test literal Interval thrown exception" in {
+    test(new StaticModule(1.I)) { c =>
+      val ex = intercept[LiteralTypeException] {
+        c.out.litPeek()
+      }
+    }
+  }
+
+}

--- a/src/test/scala/chiseltest/tests/LiteralTest.scala
+++ b/src/test/scala/chiseltest/tests/LiteralTest.scala
@@ -55,15 +55,17 @@ class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
 
   it should "test literal Boolean" in {
     test(new StaticModule(true.B)) { c =>
-      c.out.litPeek() should equal (true)
+      // Multiple ways to check the literal value
       // c.out.litPeek() should be (true) // <-- scalatest doesn't like this one
+      c.out.litPeek() should equal (true)
       c.out.litPeek() should === (true)
       c.out.litPeek() shouldBe true
       assert(c.out.litPeek() == true)
     }
     test(new StaticModule(false.B)) { c =>
-      c.out.litPeek() should equal (false)
+      // Multiple ways to check the literal value
       // c.out.litPeek() should be (false) // <-- scalatest doesn't like this one
+      c.out.litPeek() should equal (false)
       c.out.litPeek() should === (false)
       c.out.litPeek() shouldBe false
       assert(c.out.litPeek() == false)

--- a/src/test/scala/chiseltest/tests/LiteralTest.scala
+++ b/src/test/scala/chiseltest/tests/LiteralTest.scala
@@ -29,94 +29,64 @@ class LiteralVecB extends Module {
 class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
-  it should "test literal UInt as Int" in {
-    test(new StaticModule(42.U)) { c =>
-      c.out.peekInteger() shouldBe a [Int]
-      c.out.peekInteger() should be (42)
-      c.out.peekInteger() should be (BigInt(42))
-      c.out.peekInteger() should be (42.toLong)
-      assert(c.out.peekInteger() == 42)
-    }
-  }
-
-  it should "test literal SInt as Int" in {
-    test(new StaticModule(-42.S)) { c =>
-      c.out.peekInteger() shouldBe a [Int]
-      c.out.peekInteger() should be (-42)
-      c.out.peekInteger() should be (BigInt(-42))
-      c.out.peekInteger() should be (-42.toLong)
-      assert(c.out.peekInteger() == -42)
-    }
-  }
-
-  it should " test literal overflow SInt as a large Int" in {
-    test(new StaticModule(2147483648L.S)) { c =>
-      c.out.peekInteger() shouldBe a [Int]
-      c.out.peekInteger() should be (-2147483648L)
-    }
-  }
-
   it should "test literal UInt as BigInt" in {
     test(new StaticModule(42.U)) { c =>
-      c.out.peekBigInt() shouldBe a [BigInt]
-      c.out.peekBigInt() should be (42)
-      c.out.peekBigInt() should be (BigInt(42))
-      c.out.peekBigInt() should be (42.toLong)
-      assert(c.out.peekBigInt() == 42)
+      c.out.peekInt() should be (42)
+      c.out.peekInt() should be (BigInt(42))
+      c.out.peekInt() should be (42.toLong)
+      assert(c.out.peekInt() == 42)
     }
   }
 
   it should "test literal SInt as BigInt" in {
     test(new StaticModule(-42.S)) { c =>
-      c.out.peekBigInt() shouldBe a [BigInt]
-      c.out.peekBigInt() should be (-42)
-      c.out.peekBigInt() should be (BigInt(-42))
-      c.out.peekBigInt() should be (-42.toLong)
-      assert(c.out.peekBigInt() == -42)
+      c.out.peekInt() should be (-42)
+      c.out.peekInt() should be (BigInt(-42))
+      c.out.peekInt() should be (-42.toLong)
+      assert(c.out.peekInt() == -42)
     }
   }
 
   it should " test large literal SInt as BigInt" in {
     test(new StaticModule(2147483648L.S)) { c =>
-      c.out.peekBigInt() shouldBe a [BigInt]
-      c.out.peekBigInt() should be (2147483648L)
+      c.out.peekInt() should be (2147483648L)
     }
   }
 
   it should "test literal FixedPoint as BigDecimal" in {
     test(new StaticModule(10.F(2.BP))) { c =>
-      c.out.peekBigDecimal() should be (BigDecimal(10))
+      c.out.peekDec() should be (BigDecimal(10))
     }
   }
 
   it should "test literal Bool as Boolean" in {
     test(new StaticModule(true.B)) { c =>
       // Multiple ways to check the value
-      c.out.peekBoolean() should be (true)
-      assert(c.out.peekBoolean() == true)
+      c.out.peekBool() should be (true)
+      assert(c.out.peekBool() == true)
     }
     test(new StaticModule(false.B)) { c =>
       // Multiple ways to check the value
-      c.out.peekBoolean() should be (false)
-      assert(c.out.peekBoolean() == false)
+      c.out.peekBool() should be (false)
+      assert(c.out.peekBool() == false)
     }
   }
 
   it should "test literal Vector of UInt as Seq[BigInt]" in {
     test(new LiteralVecU) { c =>
-      c.out.peekVecBigInt() should be (Seq(1, 2, 4, 8))
+      c.out.peekVecInt() should be (Seq(1, 2, 4, 8))
     }
   }
 
   it should "test literal Vector of SInt as Seq[BigInt]" in {
     test(new LiteralVecS) { c =>
-      c.out.peekVecBigInt() should be (Seq(1, -2, 4, -8))
+      c.out.peekVecInt() should be (Seq(1, -2, 4, -8))
     }
   }
 
   it should "test literal Vector of Bool as Seq[Boolean]" in {
     test(new LiteralVecB) { c =>
-      c.out.peekVecBoolean() should be (Seq(true, false, true, false))
+      c.out.peekVecBool() should be (Seq(true, false, true, false))
     }
   }
 

--- a/src/test/scala/chiseltest/tests/LiteralTest.scala
+++ b/src/test/scala/chiseltest/tests/LiteralTest.scala
@@ -29,8 +29,9 @@ class LiteralVecB extends Module {
 class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
-  it should "test literal UInt as BigInt" in {
+  it should "test literal UInt as Int" in {
     test(new StaticModule(42.U)) { c =>
+      c.out.peekInt() shouldBe a [Int]
       c.out.peekInt() should be (42)
       c.out.peekInt() should be (BigInt(42))
       c.out.peekInt() should be (42.toLong)
@@ -38,12 +39,47 @@ class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
     }
   }
 
-  it should "test literal SInt as BigInt" in {
+  it should "test literal SInt as Int" in {
     test(new StaticModule(-42.S)) { c =>
+      c.out.peekInt() shouldBe a [Int]
       c.out.peekInt() should be (-42)
       c.out.peekInt() should be (BigInt(-42))
       c.out.peekInt() should be (-42.toLong)
       assert(c.out.peekInt() == -42)
+    }
+  }
+
+  it should " test literal overflow SInt as a large Int" in {
+    test(new StaticModule(2147483648L.S)) { c =>
+      c.out.peekInt() shouldBe a [Int]
+      c.out.peekInt() should be (-2147483648L)
+    }
+  }
+
+  it should "test literal UInt as BigInt" in {
+    test(new StaticModule(42.U)) { c =>
+      c.out.peekBigInt() shouldBe a [BigInt]
+      c.out.peekBigInt() should be (42)
+      c.out.peekBigInt() should be (BigInt(42))
+      c.out.peekBigInt() should be (42.toLong)
+      assert(c.out.peekBigInt() == 42)
+    }
+  }
+
+  it should "test literal SInt as BigInt" in {
+    test(new StaticModule(-42.S)) { c =>
+      c.out.peekBigInt() shouldBe a [BigInt]
+      c.out.peekBigInt() should be (-42)
+      c.out.peekBigInt() should be (BigInt(-42))
+      c.out.peekBigInt() should be (-42.toLong)
+      assert(c.out.peekBigInt() == -42)
+    }
+  }
+
+  it should " test large literal SInt as BigInt" in {
+    test(new StaticModule(2147483648L.S)) { c =>
+      c.out.peekBigInt() shouldBe a [BigInt]
+      c.out.peekBigInt() should be (2147483648L)
     }
   }
 
@@ -68,19 +104,19 @@ class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
 
   it should "test literal Vector of UInt as Seq[BigInt]" in {
     test(new LiteralVecU) { c =>
-      c.out.peekVectorInt() should be (Seq(1, 2, 4, 8))
+      c.out.peekVecBigInt() should be (Seq(1, 2, 4, 8))
     }
   }
 
   it should "test literal Vector of SInt as Seq[BigInt]" in {
     test(new LiteralVecS) { c =>
-      c.out.peekVectorInt() should be (Seq(1, -2, 4, -8))
+      c.out.peekVecBigInt() should be (Seq(1, -2, 4, -8))
     }
   }
 
   it should "test literal Vector of Bool as Seq[Boolean]" in {
     test(new LiteralVecB) { c =>
-      c.out.peekVectorBool() should be (Seq(true, false, true, false))
+      c.out.peekVecBool() should be (Seq(true, false, true, false))
     }
   }
 

--- a/src/test/scala/chiseltest/tests/LiteralTest.scala
+++ b/src/test/scala/chiseltest/tests/LiteralTest.scala
@@ -31,28 +31,28 @@ class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
 
   it should "test literal UInt as Int" in {
     test(new StaticModule(42.U)) { c =>
-      c.out.peekInt() shouldBe a [Int]
-      c.out.peekInt() should be (42)
-      c.out.peekInt() should be (BigInt(42))
-      c.out.peekInt() should be (42.toLong)
-      assert(c.out.peekInt() == 42)
+      c.out.peekInteger() shouldBe a [Int]
+      c.out.peekInteger() should be (42)
+      c.out.peekInteger() should be (BigInt(42))
+      c.out.peekInteger() should be (42.toLong)
+      assert(c.out.peekInteger() == 42)
     }
   }
 
   it should "test literal SInt as Int" in {
     test(new StaticModule(-42.S)) { c =>
-      c.out.peekInt() shouldBe a [Int]
-      c.out.peekInt() should be (-42)
-      c.out.peekInt() should be (BigInt(-42))
-      c.out.peekInt() should be (-42.toLong)
-      assert(c.out.peekInt() == -42)
+      c.out.peekInteger() shouldBe a [Int]
+      c.out.peekInteger() should be (-42)
+      c.out.peekInteger() should be (BigInt(-42))
+      c.out.peekInteger() should be (-42.toLong)
+      assert(c.out.peekInteger() == -42)
     }
   }
 
   it should " test literal overflow SInt as a large Int" in {
     test(new StaticModule(2147483648L.S)) { c =>
-      c.out.peekInt() shouldBe a [Int]
-      c.out.peekInt() should be (-2147483648L)
+      c.out.peekInteger() shouldBe a [Int]
+      c.out.peekInteger() should be (-2147483648L)
     }
   }
 
@@ -85,20 +85,20 @@ class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
 
   it should "test literal FixedPoint as BigDecimal" in {
     test(new StaticModule(10.F(2.BP))) { c =>
-      c.out.peekDecimal() should be (BigDecimal(10))
+      c.out.peekBigDecimal() should be (BigDecimal(10))
     }
   }
 
   it should "test literal Bool as Boolean" in {
     test(new StaticModule(true.B)) { c =>
       // Multiple ways to check the value
-      c.out.peekBool() should be (true)
-      assert(c.out.peekBool() == true)
+      c.out.peekBoolean() should be (true)
+      assert(c.out.peekBoolean() == true)
     }
     test(new StaticModule(false.B)) { c =>
       // Multiple ways to check the value
-      c.out.peekBool() should be (false)
-      assert(c.out.peekBool() == false)
+      c.out.peekBoolean() should be (false)
+      assert(c.out.peekBoolean() == false)
     }
   }
 
@@ -116,7 +116,7 @@ class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
 
   it should "test literal Vector of Bool as Seq[Boolean]" in {
     test(new LiteralVecB) { c =>
-      c.out.peekVecBool() should be (Seq(true, false, true, false))
+      c.out.peekVecBoolean() should be (Seq(true, false, true, false))
     }
   }
 

--- a/src/test/scala/chiseltest/tests/LiteralTest.scala
+++ b/src/test/scala/chiseltest/tests/LiteralTest.scala
@@ -10,22 +10,6 @@ import chiseltest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class LiteralVecU extends Module {
-  val out   = IO(Output(Vec(4, UInt(8.W))))
-  val v = VecInit(1.U, 2.U, 4.U, 8.U)
-  out := v
-}
-class LiteralVecS extends Module {
-  val out   = IO(Output(Vec(4, SInt(8.W))))
-  val v = VecInit(1.S, -2.S, 4.S, -8.S)
-  out := v
-}
-class LiteralVecB extends Module {
-  val out   = IO(Output(Vec(4, Bool())))
-  val v = VecInit(true.B, false.B, true.B, false.B)
-  out := v
-}
-
 class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 

--- a/src/test/scala/chiseltest/tests/LiteralTest.scala
+++ b/src/test/scala/chiseltest/tests/LiteralTest.scala
@@ -53,40 +53,16 @@ class LiteralTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
     }
   }
 
-  it should "test literal FixedPoint as BigDecimal" in {
-    test(new StaticModule(10.F(2.BP))) { c =>
-      c.out.peekDec() should be (BigDecimal(10))
-    }
-  }
-
   it should "test literal Bool as Boolean" in {
     test(new StaticModule(true.B)) { c =>
       // Multiple ways to check the value
-      c.out.peekBool() should be (true)
-      assert(c.out.peekBool() == true)
+      c.out.peekBoolean() should be (true)
+      assert(c.out.peekBoolean() == true)
     }
     test(new StaticModule(false.B)) { c =>
       // Multiple ways to check the value
-      c.out.peekBool() should be (false)
-      assert(c.out.peekBool() == false)
-    }
-  }
-
-  it should "test literal Vector of UInt as Seq[BigInt]" in {
-    test(new LiteralVecU) { c =>
-      c.out.peekVecInt() should be (Seq(1, 2, 4, 8))
-    }
-  }
-
-  it should "test literal Vector of SInt as Seq[BigInt]" in {
-    test(new LiteralVecS) { c =>
-      c.out.peekVecInt() should be (Seq(1, -2, 4, -8))
-    }
-  }
-
-  it should "test literal Vector of Bool as Seq[Boolean]" in {
-    test(new LiteralVecB) { c =>
-      c.out.peekVecBool() should be (Seq(true, false, true, false))
+      c.out.peekBoolean() should be (false)
+      assert(c.out.peekBoolean() == false)
     }
   }
 


### PR DESCRIPTION
This PR adds a peek method that returns Scala types instead of Chisel types.

This makes a cleaner syntax avoiding the use of `peek().litValue` simplifying the use of scalatest or other test framework matchers.

The method name is a suggestion.