### PR TITLE
Implements a feature that allows DUT's to specify a simulation timeout

### DIFF
--- a/src/main/scala/chiseltest/internal/HardwareTesterBackend.scala
+++ b/src/main/scala/chiseltest/internal/HardwareTesterBackend.scala
@@ -4,7 +4,15 @@ import chisel3.Module
 import chisel3.testers.BasicTester
 import chiseltest.{defaults, ChiselAssertionError, StopException, TimeoutException}
 import chiseltest.coverage.{Coverage, TestCoverage}
-import chiseltest.simulator.{Compiler, DebugPrintWrapper, DutSpecifiesTimeout, Simulator, SimulatorContext, StepInterrupted, StepOk}
+import chiseltest.simulator.{
+  Compiler,
+  DebugPrintWrapper,
+  DutSpecifiesTimeout,
+  Simulator,
+  SimulatorContext,
+  StepInterrupted,
+  StepOk
+}
 import firrtl.AnnotationSeq
 
 /** Backend that allows us to run hardware testers in the style of `chisel3.testers.BasicTester` efficiently.

--- a/src/main/scala/chiseltest/simulator/Simulator.scala
+++ b/src/main/scala/chiseltest/simulator/Simulator.scala
@@ -4,6 +4,14 @@ package chiseltest.simulator
 
 import firrtl._
 import firrtl.annotations.NoTargetAnnotation
+import chisel3.Module
+
+// Include this trait to allow the DUT to specify the testing timeout
+trait DutSpecifiesTimeout {
+  self: Module =>
+
+  def timeout: Int
+}
 
 /** context for a running firrtl circuit simulation */
 trait SimulatorContext {
@@ -54,6 +62,10 @@ trait SimulatorContext {
     */
   def resetCoverage(): Unit =
     throw new NotImplementedError(s"${sim.name} does not support coverage!")
+
+  /** If not None then this timeout overrides the timeout provided to the test harness
+    */
+  var dutSpecifiedTimeoutOpt: Option[Int] = None
 }
 
 sealed trait StepResult

--- a/src/test/scala/chiseltest/simulator/DutSpecifiesTimeoutSpec.scala
+++ b/src/test/scala/chiseltest/simulator/DutSpecifiesTimeoutSpec.scala
@@ -1,0 +1,73 @@
+package chiseltest.simulator
+
+import chisel3.testers.BasicTester
+import chisel3._
+import chiseltest.{ChiselAssertionError, ChiselScalatestTester, TimeoutException}
+import org.scalatest.freespec.AnyFreeSpec
+
+// Based on tests in HardwareTestsTest
+class StopFailTimeoutDutWithDutSpecifiedTimeout(
+  stopAtCount: Int = 0,
+  failAtCount: Int = 0,
+  val timeout: Int)
+    extends BasicTester
+    with DutSpecifiesTimeout {
+  val counter = RegInit(0.U(33.W))
+  val nextCounterValue = counter + 1.U
+  counter := nextCounterValue
+
+  if (stopAtCount > 0) {
+    // we want to trigger the stop at the same clock tick when
+    // the counter register is updated to the stopAtCount
+    when(nextCounterValue >= stopAtCount.U) {
+      stop()
+    }
+  }
+  if (failAtCount > 0) {
+    // we want to trigger the assert at the same clock tick when
+    // the counter register is updated to the failAtCount
+    when(nextCounterValue >= failAtCount.U) {
+      assert(0.U === 1.U)
+    }
+  }
+
+}
+
+class DutSpecifiesTimeoutSpec extends AnyFreeSpec with ChiselScalatestTester {
+  "Should timeout if stopAt exceeds timeout" in {
+    intercept[TimeoutException] {
+      test(new StopFailTimeoutDutWithDutSpecifiedTimeout(stopAtCount = 1501, failAtCount = 4000, timeout = 1500))
+        .runUntilStop()
+    }
+  }
+
+  "Should not timeout if stopAt is equal to timeout" in {
+    test(new StopFailTimeoutDutWithDutSpecifiedTimeout(stopAtCount = 1500, failAtCount = 4000, timeout = 1500))
+      .runUntilStop()
+  }
+
+  "Should not timeout if stopAt is less than timeout" in {
+    test(new StopFailTimeoutDutWithDutSpecifiedTimeout(stopAtCount = 300, failAtCount = 4000, timeout = 1500))
+      .runUntilStop()
+  }
+
+  "Should timeout if failAtCount is greater than timeout" in {
+    intercept[TimeoutException] {
+      test(new StopFailTimeoutDutWithDutSpecifiedTimeout(stopAtCount = 6000, failAtCount = 1501, timeout = 1500))
+        .runUntilStop()
+    }
+  }
+  "Should fail if failAtCount is less than timeout" in {
+    intercept[ChiselAssertionError] {
+      test(new StopFailTimeoutDutWithDutSpecifiedTimeout(stopAtCount = 6000, failAtCount = 400, timeout = 1500))
+        .runUntilStop()
+    }
+  }
+
+  "Should fail if failAtCount is equal to timeout" in {
+    intercept[ChiselAssertionError] {
+      test(new StopFailTimeoutDutWithDutSpecifiedTimeout(stopAtCount = 6000, failAtCount = 1500, timeout = 1500))
+        .runUntilStop()
+    }
+  }
+}


### PR DESCRIPTION
Implements a rocket-chip compatibility feature that allows DUT's to specify a simulation timeout

Rocket-chip's technique of having the DUT carry the timeout simulation conflicts with the late
and very low level evaluation of the DUT generator function. This means that rocket-chip cannot
take advantage of the relatively new `runUntilStop` method. This PR provides a mechanism for
chiseltest to use it.
When the DUT is generated, return the DUT up the chain. If the DUT inherits from `DutSpecifiesTimeout`
then use the `timeout` specified there instead of the `timeout` paramter to `runUntilStop`
A test demonstrating this working is in DutSpecifiesTimeoutSpec