### PR TITLE
Remove VCS warning

### DIFF
--- a/src/main/scala/chiseltest/simulator/VcsSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VcsSimulator.scala
@@ -169,20 +169,22 @@ private object VcsSimulator extends Simulator {
   )
 
   private def DefaultFlags(topName: String, cFlags: Seq[String], verdiFlags: Seq[String]) = List(
-    "-full64",
-    "-quiet",
-    "-sverilog",
-    "-timescale=1ns/1ps",
-    "-debug_acc+pp+dmptf",
-    "-debug_region+cell+encrypt",
+    "-full64",                    /* Default using 64-bit VCS*/
+    "-quiet",                     /* Quite mode*/
+    "-sverilog",                  /* Harness is written in SystemVerilog*/
+    "-timescale=1ns/1ps",         /* Clock Period*/
+    "-debug_acc+pp+dmptf",        /* pp: registers and variables, callbacks, driver, and assertion debug capability*/
+                                  /* dmptf: debug ports and internal nodes/memories of tasks/functions*/
+    "-debug_region+cell+encrypt", /* cell: debug both real cell modules and the ports of real cell modules*/
+                                  /* encrypt: debug fully-encrypted instances*/
     s"-Mdir=$topName.csrc",
-    "+v2k",
+    "+v2k",                       /* verilog 2000 standard*/
     "+vpi",
-    "+vcs+lic+wait",
-    "+vcs+initreg+random",
-    "+define+CLOCK_PERIOD=1",
-    "-P",
-    "vpi.tab",
+    "+vcs+lic+wait",              /* wait for VCS license if there isn't one*/
+    "+vcs+initreg+random",        /* Randomize the register*/
+    "+define+CLOCK_PERIOD=1",     /* Define the clock period*/
+    "-P",                         /* Pass vpi.tab*/
+    "vpi.tab",                    /* like above*/
     "-cpp",
     "g++",
     "-O2",

--- a/src/main/scala/chiseltest/simulator/VcsSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VcsSimulator.scala
@@ -169,22 +169,24 @@ private object VcsSimulator extends Simulator {
   )
 
   private def DefaultFlags(topName: String, cFlags: Seq[String], verdiFlags: Seq[String]) = List(
-    "-full64",                    /* Default using 64-bit VCS*/
-    "-quiet",                     /* Quite mode*/
-    "-sverilog",                  /* Harness is written in SystemVerilog*/
-    "-timescale=1ns/1ps",         /* Clock Period*/
-    "-debug_acc+pp+dmptf",        /* pp: registers and variables, callbacks, driver, and assertion debug capability*/
-                                  /* dmptf: debug ports and internal nodes/memories of tasks/functions*/
-    "-debug_region+cell+encrypt", /* cell: debug both real cell modules and the ports of real cell modules*/
-                                  /* encrypt: debug fully-encrypted instances*/
+    "-full64", /* Default using 64-bit VCS*/
+    "-quiet", /* Quite mode*/
+    "-sverilog", /* Harness is written in SystemVerilog*/
+    "-timescale=1ns/1ps", /* Clock Period*/
+    /* pp: registers and variables, callbacks, driver, and assertion debug capability*/
+    /* dmptf: debug ports and internal nodes/memories of tasks/functions*/
+    "-debug_acc+pp+dmptf",
+    /* cell: debug both real cell modules and the ports of real cell modules*/
+    /* encrypt: debug fully-encrypted instances*/
+    "-debug_region+cell+encrypt",
     s"-Mdir=$topName.csrc",
-    "+v2k",                       /* verilog 2000 standard*/
+    "+v2k", /* verilog 2000 standard*/
     "+vpi",
-    "+vcs+lic+wait",              /* wait for VCS license if there isn't one*/
-    "+vcs+initreg+random",        /* Randomize the register*/
-    "+define+CLOCK_PERIOD=1",     /* Define the clock period*/
-    "-P",                         /* Pass vpi.tab*/
-    "vpi.tab",                    /* like above*/
+    "+vcs+lic+wait", /* wait for VCS license if there isn't one*/
+    "+vcs+initreg+random", /* Randomize the register*/
+    "+define+CLOCK_PERIOD=1", /* Define the clock period*/
+    "-P", /* Pass vpi.tab*/
+    "vpi.tab", /* like above*/
     "-cpp",
     "g++",
     "-O2",

--- a/src/main/scala/chiseltest/simulator/VcsSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VcsSimulator.scala
@@ -104,7 +104,7 @@ private object VcsSimulator extends Simulator {
     val ext = Simulator.getWavformFormat(annos)
     val dumpfile = targetDir.relativeTo(os.pwd) / s"$topName.$ext"
     if (ext.isEmpty) {
-      Seq("-none")
+      Seq.empty
     } else if (ext == "vpd") {
       Seq(s"+vcdplusfile=${dumpfile.toString()}")
     } else if (ext == "fsdb") {
@@ -173,7 +173,8 @@ private object VcsSimulator extends Simulator {
     "-quiet",
     "-sverilog",
     "-timescale=1ns/1ps",
-    "-debug_pp",
+    "-debug_acc+pp+dmptf",
+    "-debug_region+cell+encrypt",
     s"-Mdir=$topName.csrc",
     "+v2k",
     "+vpi",

--- a/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
@@ -83,7 +83,7 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
     codeBuffer.append(s"  always @(negedge $clockName)  begin\n")
     codeBuffer.append(s"    if ($dumpFileVar && !$dumpOnVar) begin\n")
     codeBuffer.append(s"      $dumpOnVar = 1;\n")
-    if(useFsdbDump) codeBuffer.append("      $fsdbDumpon;\n")
+    if (useFsdbDump) codeBuffer.append("      $fsdbDumpon;\n")
     else codeBuffer.append("      $dumpon;\n")
     codeBuffer.append("    end\n")
     codeBuffer.append("    $tick();\n")

--- a/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
@@ -55,6 +55,8 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
       codeBuffer.append("    /*** Enable VPD dump ***/\n")
       codeBuffer.append("    if ($value$plusargs(\"vcdplusfile=%s\", " + dumpFileVar + ")) begin\n")
       codeBuffer.append(s"      $$vcdplusfile($dumpFileVar);\n")
+      codeBuffer.append(s"      $$dumpfile($dumpFileVar);\n")
+      codeBuffer.append(s"      $$dumpvars(0, $dutName);\n")
       codeBuffer.append(s"      $$vcdpluson;\n")
       codeBuffer.append("    end\n")
     }
@@ -81,7 +83,8 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
     codeBuffer.append(s"  always @(negedge $clockName)  begin\n")
     codeBuffer.append(s"    if ($dumpFileVar && !$dumpOnVar) begin\n")
     codeBuffer.append(s"      $dumpOnVar = 1;\n")
-    codeBuffer.append("      $dumpon;\n")
+    if(useFsdbDump) codeBuffer.append("      $fsdbDumpon;\n")
+    else codeBuffer.append("      $dumpon;\n")
     codeBuffer.append("    end\n")
     codeBuffer.append("    $tick();\n")
     codeBuffer.append("    $dumpflush;\n")


### PR DESCRIPTION
Three VCS warnings are removed
1. Remove `-none` when no waveform annotation is given, `-none` is not a valid VCS option
```
Warning-[RT_UO] Unsupported option
  Unsupported option '-none' is ignored
```
2. Replace `debug_pp` per VCS suggested
```
Warning-[DEBUG_DEP] Option will be deprecated
  The option '-debug_pp' will be deprecated in a future release.  
  Please use '-debug_acc+pp+dmptf -debug_region+cell+encrypt' instead.
```
3. Reposition `dumpvars` per IEEE Standard
```
Warning-[TFX-DUMPVARCA] DumpVar called previously
  As $dumpvars was called in previous time step, ignoring this call.$dumpfile at time #1000
  Please refer to section 18.1.2 in the IEEE Verilog Standard 1364-2001 for details on $dumpvars.
```

Local UnitTest Passed: `sbt "testOnly chiseltest.simulator.VcsWaveformCompliance"`
VCS/DVE Version: `S-2021.09-SP1`
Verdi Version: `S-2021.09-SP1`
GCC Version: `gcc version 9.2.1 20191120 (Red Hat 9.2.1-2) (GCC)`