### PR TITLE
formal: demote simulation/formal mismach to a warning

### DIFF
--- a/src/main/scala/chiseltest/formal/backends/TransitionSystemSimulator.scala
+++ b/src/main/scala/chiseltest/formal/backends/TransitionSystemSimulator.scala
@@ -230,14 +230,19 @@ private[chiseltest] class TransitionSystemSimulator(
     def failedPropertiesMsg: String =
       s"Failed (${failed.size}) properties in step #$index:\n${failed.map(failedMsg).mkString("\n")}"
     expectedFailed match {
-      case None =>
-        assert(failed.isEmpty, "Unexpected failure!! " + failedPropertiesMsg)
+      case None if failed.isEmpty => // great!
+      case None => // oh no
+        println(
+          "Warn: Potential simulation/formal mismatch.\n" +
+            s"In step #$index: Unexpected failure!! " + failedPropertiesMsg
+        )
       case Some(Seq()) => // this means that we do not know which exact property is supposed to fail
       case Some(props) =>
         val failedSet = failed.toSet
         if (!props.toSet.subsetOf(failedSet)) {
           println(
-            s"In step #$index: Expected properties ${props.mkString(", ")} to fail, instead ${failed.mkString(", ")} failed"
+            "Warn: Potential simulation/formal mismatch.\n" +
+              s"In step #$index: Expected properties ${props.mkString(", ")} to fail, instead ${failed.mkString(", ")} failed"
           )
         }
     }


### PR DESCRIPTION
I have an example right now, where one simulation replay seems to fail, while another succeeds. This means that there is a bug in `chiseltest` which I have not yet been able to find. However, for normal users, I believe it would be better for them to be able to continue without an exception terminating their test.