### PR TITLE
Scala type peek poke

### DIFF
--- a/src/main/scala/chiseltest/internal/BackendInterface.scala
+++ b/src/main/scala/chiseltest/internal/BackendInterface.scala
@@ -46,17 +46,15 @@ trait BackendInterface {
   def pokeBits(signal: Data, value: BigInt): Unit
 
   /** Returns the current value on a wire.
-    * If stale is true, returns the current combinational value (after previous pokes have taken effect).
-    * If stale is false, returns the value at the beginning of the current cycle.
+    * Returns the current combinational value (after previous pokes have taken effect).
     */
-  def peekBits(signal: Data, stale: Boolean): BigInt
+  def peekBits(signal: Data): BigInt
 
   def expectBits(
     signal:  Data,
     value:   BigInt,
-    message: Option[String],
-    decode:  Option[BigInt => String],
-    stale:   Boolean
+    message: Option[() => String],
+    decode:  Option[BigInt => String]
   ): Unit
 
   /** Sets the timeout of the clock: the number of cycles the clock can advance without

--- a/src/main/scala/chiseltest/internal/BackendInterface.scala
+++ b/src/main/scala/chiseltest/internal/BackendInterface.scala
@@ -50,12 +50,8 @@ trait BackendInterface {
     */
   def peekBits(signal: Data): BigInt
 
-  def expectBits(
-    signal:  Data,
-    value:   BigInt,
-    message: Option[() => String],
-    decode:  Option[BigInt => String]
-  ): Unit
+  /** Returns a human readable name of a signal. */
+  def resolveName(signal: Data): String
 
   /** Sets the timeout of the clock: the number of cycles the clock can advance without
     * some non-nop poke operation.

--- a/src/main/scala/chiseltest/internal/GenericBackend.scala
+++ b/src/main/scala/chiseltest/internal/GenericBackend.scala
@@ -72,9 +72,7 @@ class GenericBackend[T <: Module](
     debugLog(s"${resolveName(signal)} <- $value")
   }
 
-  override def peekBits(signal: Data, stale: Boolean): BigInt = {
-    require(!stale, "Stale peek not yet implemented")
-
+  override def peekBits(signal: Data): BigInt = {
     doPeek(signal, new Throwable)
     val a = tester.peek(dataNames(signal))
     debugLog(s"${resolveName(signal)} -> $a")
@@ -84,14 +82,12 @@ class GenericBackend[T <: Module](
   override def expectBits(
     signal:  Data,
     value:   BigInt,
-    message: Option[String],
-    decode:  Option[BigInt => String],
-    stale:   Boolean
+    message: Option[() => String],
+    decode:  Option[BigInt => String]
   ): Unit = {
-    require(!stale, "Stale peek not yet implemented")
 
     debugLog(s"${resolveName(signal)} ?> $value")
-    Context().env.testerExpect(value, peekBits(signal, stale), resolveName(signal), message, decode)
+    Context().env.testerExpect(value, peekBits(signal), resolveName(signal), message, decode)
   }
 
   protected val clockCounter: mutable.HashMap[Clock, Int] = mutable.HashMap()

--- a/src/main/scala/chiseltest/internal/GenericBackend.scala
+++ b/src/main/scala/chiseltest/internal/GenericBackend.scala
@@ -28,7 +28,7 @@ class GenericBackend[T <: Module](
     if (verbose) println(str)
   }
 
-  protected def resolveName(signal: Data): String = { // TODO: unify w/ dataNames?
+  override def resolveName(signal: Data): String = {
     dataNames.getOrElse(signal, signal.toString)
   }
 
@@ -77,17 +77,6 @@ class GenericBackend[T <: Module](
     val a = tester.peek(dataNames(signal))
     debugLog(s"${resolveName(signal)} -> $a")
     a
-  }
-
-  override def expectBits(
-    signal:  Data,
-    value:   BigInt,
-    message: Option[() => String],
-    decode:  Option[BigInt => String]
-  ): Unit = {
-
-    debugLog(s"${resolveName(signal)} ?> $value")
-    Context().env.testerExpect(value, peekBits(signal), resolveName(signal), message, decode)
   }
 
   protected val clockCounter: mutable.HashMap[Clock, Int] = mutable.HashMap()

--- a/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
+++ b/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
@@ -18,7 +18,7 @@ class SingleThreadBackend[T <: Module](
   coverageAnnotations:    AnnotationSeq)
     extends BackendInstance[T] {
 
-  private def resolveName(signal: Data): String = { // TODO: unify w/ dataNames?
+  override def resolveName(signal: Data): String = {
     dataNames.getOrElse(signal, signal.toString)
   }
 
@@ -55,15 +55,6 @@ class SingleThreadBackend[T <: Module](
   override def peekBits(signal: Data): BigInt = {
     val a = tester.peek(dataNames(signal))
     a
-  }
-
-  override def expectBits(
-    signal:  Data,
-    value:   BigInt,
-    message: Option[() => String],
-    decode:  Option[BigInt => String]
-  ): Unit = {
-    Context().env.testerExpect(value, peekBits(signal), resolveName(signal), message, decode)
   }
 
   override def doTimescope(contents: () => Unit): Unit = {

--- a/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
+++ b/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
@@ -52,8 +52,7 @@ class SingleThreadBackend[T <: Module](
     }
   }
 
-  override def peekBits(signal: Data, stale: Boolean): BigInt = {
-    require(!stale, "Stale peek not yet implemented")
+  override def peekBits(signal: Data): BigInt = {
     val a = tester.peek(dataNames(signal))
     a
   }
@@ -61,12 +60,10 @@ class SingleThreadBackend[T <: Module](
   override def expectBits(
     signal:  Data,
     value:   BigInt,
-    message: Option[String],
-    decode:  Option[BigInt => String],
-    stale:   Boolean
+    message: Option[() => String],
+    decode:  Option[BigInt => String]
   ): Unit = {
-    require(!stale, "Stale peek not yet implemented")
-    Context().env.testerExpect(value, peekBits(signal, stale), resolveName(signal), message, decode)
+    Context().env.testerExpect(value, peekBits(signal), resolveName(signal), message, decode)
   }
 
   override def doTimescope(contents: () => Unit): Unit = {

--- a/src/main/scala/chiseltest/internal/TestEnvInterface.scala
+++ b/src/main/scala/chiseltest/internal/TestEnvInterface.scala
@@ -54,12 +54,12 @@ trait TestEnvInterface {
     expected: BigInt,
     actual:   BigInt,
     signal:   String,
-    msg:      Option[String],
+    msg:      Option[() => String],
     decode:   Option[BigInt => String]
   ): Unit = {
     if (expected != actual) {
       val appendMsg = msg match {
-        case Some(_) => s": $msg"
+        case Some(m) => s": ${m()}"
         case _       => ""
       }
 

--- a/src/main/scala/chiseltest/internal/TestEnvInterface.scala
+++ b/src/main/scala/chiseltest/internal/TestEnvInterface.scala
@@ -65,7 +65,7 @@ trait TestEnvInterface {
 
       val trace = new Throwable
       val expectStackDepth = trace.getStackTrace.indexWhere(ste =>
-        ste.getClassName == "chiseltest.package$testableData" && ste.getMethodName == "expect"
+        ste.getClassName.startsWith("chiseltest.package$") && ste.getMethodName == "expect"
       )
       require(
         expectStackDepth != -1,

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -173,80 +173,75 @@ package object chiseltest {
       // TODO: aggregate types
     }
 
-    protected def peekWithStale(stale: Boolean): T = x match {
-      case (x: Bool) =>
-        Context().backend.peekBits(x, stale) match {
+    def peek(): T = x match {
+      case x: Bool =>
+        Context().backend.peekBits(x) match {
           case x: BigInt if x == 0 => false.B.asInstanceOf[T]
           case x: BigInt if x == 1 => true.B.asInstanceOf[T]
           case x => throw new LiteralTypeException(s"peeked Bool with value $x not 0 or 1")
         }
-      case (x: UInt) => Context().backend.peekBits(x, stale).asUInt(DataMirror.widthOf(x)).asInstanceOf[T]
-      case (x: SInt) => Context().backend.peekBits(x, stale).asSInt(DataMirror.widthOf(x)).asInstanceOf[T]
-      case (x: FixedPoint) => {
+      case x: UInt => Context().backend.peekBits(x).asUInt(DataMirror.widthOf(x)).asInstanceOf[T]
+      case x: SInt => Context().backend.peekBits(x).asSInt(DataMirror.widthOf(x)).asInstanceOf[T]
+      case x: FixedPoint =>
         val multiplier = BigDecimal(2).pow(x.binaryPoint.get)
-        (BigDecimal(Context().backend.peekBits(x, stale)) / multiplier).F(x.binaryPoint).asInstanceOf[T]
-      }
+        (BigDecimal(Context().backend.peekBits(x)) / multiplier).F(x.binaryPoint).asInstanceOf[T]
       case x: Interval =>
-        Context().backend.peekBits(x, stale).I(x.binaryPoint).asInstanceOf[T]
-      case (x: Record) => {
+        Context().backend.peekBits(x).I(x.binaryPoint).asInstanceOf[T]
+      case x: Record =>
         val elementValueFns = x.elements.map { case (name: String, elt: Data) =>
-          (y: Record) => (y.elements(name), elt.peekWithStale(stale))
+          (y: Record) => (y.elements(name), elt.peek())
         }.toSeq
         chiselTypeOf(x).Lit(elementValueFns: _*).asInstanceOf[T]
-      }
-      case (x: Vec[_]) =>
+      case x: Vec[_] =>
         val elementValueFns = x.getElements.map { case elt: Data =>
-          elt.peekWithStale(stale)
+          elt.peek()
         }
         Vec.Lit(elementValueFns: _*).asInstanceOf[T]
-      case (x: EnumType) => {
+      case x: EnumType =>
         throw new NotImplementedError(s"peeking enums ($x) not yet supported, need programmatic enum construction")
-      }
       case x => throw new LiteralTypeException(s"don't know how to peek $x")
     }
 
-    def peek(): T = peekWithStale(false)
-
-    protected def expectWithStale(value: T, message: Option[String], stale: Boolean): Unit = (x, value) match {
+    protected def expect(value: T, message: Option[() => String]): Unit = (x, value) match {
       case (x: Bool, value: Bool) =>
-        Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.boolBitsToString), stale)
+        Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.boolBitsToString))
       // TODO can't happen because of type parameterization
       case (x: Bool, value: Bits) =>
         throw new LiteralTypeException(s"cannot expect non-Bool value $value from Bool IO $x")
-      case (x: Bits, value: UInt) => Context().backend.expectBits(x, value.litValue, message, None, stale)
-      case (x: SInt, value: SInt) => Context().backend.expectBits(x, value.litValue, message, None, stale)
+      case (x: Bits, value: UInt) => Context().backend.expectBits(x, value.litValue, message, None)
+      case (x: SInt, value: SInt) => Context().backend.expectBits(x, value.litValue, message, None)
       // TODO can't happen because of type parameterization
       case (x: Bits, value: SInt) =>
         throw new LiteralTypeException(s"cannot expect non-SInt value $value from SInt IO $x")
       case (x: FixedPoint, value: FixedPoint) => {
         require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
-        Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.fixedToString(x.binaryPoint)), stale)
+        Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.fixedToString(x.binaryPoint)))
       }
       case (x: Interval, value: Interval) =>
         require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
-        Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.fixedToString(x.binaryPoint)), stale)
+        Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.fixedToString(x.binaryPoint)))
       case (x: Record, value: Record) => {
         require(DataMirror.checkTypeEquivalence(x, value), s"Record type mismatch")
         (x.elements.zip(value.elements)).foreach { case ((_, x), (_, value)) =>
-          x.expectWithStale(value, message, stale)
+          x.expect(value, message)
         }
       }
       case (x: Vec[_], value: Vec[_]) => {
         require(DataMirror.checkTypeEquivalence(x, value), s"Vec type mismatch")
         (x.getElements.zip(value.getElements)).foreach { case (x, value) =>
-          x.expectWithStale(value, message, stale)
+          x.expect(value, message)
         }
       }
       case (x: EnumType, value: EnumType) => {
         require(DataMirror.checkTypeEquivalence(x, value), s"EnumType mismatch")
-        Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.enumToString(x)), stale)
+        Context().backend.expectBits(x, value.litValue, message, Some(BitsDecoders.enumToString(x)))
       }
       case x => throw new LiteralTypeException(s"don't know how to expect $x")
       // TODO: aggregate types
     }
 
-    def expect(value: T): Unit = expectWithStale(value, None, false)
-    def expect(value: T, message: String): Unit = expectWithStale(value, Some(message), false)
+    def expect(value: T): Unit = expect(value, None)
+    def expect(value: T, message: => String): Unit = expect(value, Some(() => message))
 
     /** @return the single clock that drives the source of this signal.
       * @throws ClockResolutionException if sources of this signal have more than one, or zero clocks

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -130,6 +130,58 @@ package object chiseltest {
     }
   }
 
+  /** allows access to chisel FixedPoint type signals with Scala native values */
+  implicit class testableFixedPoint(x: FixedPoint) {
+    private def asFixedPoint(value: Double):     FixedPoint = value.F(Utils.getFirrtlWidth(x), x.binaryPoint)
+    private def asFixedPoint(value: BigDecimal): FixedPoint = value.F(Utils.getFirrtlWidth(x), x.binaryPoint)
+    def poke(value: FixedPoint): Unit = {
+      require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
+      Utils.pokeBits(x, value.litValue)
+    }
+    def poke(value: Double):     Unit = poke(asFixedPoint(value))
+    def poke(value: BigDecimal): Unit = poke(asFixedPoint(value))
+    private[chiseltest] def expectInternal(value: FixedPoint, message: Option[() => String]): Unit = {
+      require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
+      Context().backend.expectBits(x, value.litValue, message, Some(Utils.fixedToString(x.binaryPoint)))
+    }
+    def expect(value: FixedPoint): Unit = expectInternal(value, None)
+    def expect(value: FixedPoint, message: => String): Unit = expectInternal(value, Some(() => message))
+    private[chiseltest] def expectInternal(value: Double, epsilon: Double, message: Option[() => String]): Unit = {
+      ???
+    }
+    def expect(value: Double): Unit = expectInternal(value, epsilon = 0.01, None)
+    def expect(value: Double, epsilon: Double): Unit = expectInternal(value, epsilon = epsilon, None)
+    def expect(value: Double, message: => String): Unit =
+      expectInternal(value, epsilon = 0.01, Some(() => message))
+    def expect(value: Double, message: => String, epsilon: Double): Unit =
+      expectInternal(value, epsilon = epsilon, Some(() => message))
+    private[chiseltest] def expectInternal(
+      value:   BigDecimal,
+      epsilon: BigDecimal,
+      message: Option[() => String]
+    ): Unit = {
+      ???
+    }
+    def expect(value: BigDecimal): Unit = expectInternal(value, epsilon = 0.01, None)
+    def expect(value: BigDecimal, epsilon: BigDecimal): Unit = expectInternal(value, epsilon = epsilon, None)
+    def expect(value: BigDecimal, message: => String): Unit =
+      expectInternal(value, epsilon = 0.01, Some(() => message))
+    def expect(value: BigDecimal, message: => String, epsilon: BigDecimal): Unit =
+      expectInternal(value, epsilon = epsilon, Some(() => message))
+    def peek(): FixedPoint = {
+      val multiplier = BigDecimal(2).pow(x.binaryPoint.get)
+      (BigDecimal(Context().backend.peekBits(x)) / multiplier).F(x.binaryPoint)
+    }
+    def peekDouble(): Double = x.binaryPoint match {
+      case KnownBinaryPoint(bp) => FixedPoint.toDouble(Context().backend.peekBits(x), bp)
+      case _                    => throw new Exception("Cannot peekInterval with unknown binary point location")
+    }
+    def peekBigDecimal(): BigDecimal = x.binaryPoint match {
+      case KnownBinaryPoint(bp) => FixedPoint.toBigDecimal(Context().backend.peekBits(x), bp)
+      case _                    => throw new Exception("Cannot peekInterval with unknown binary point location")
+    }
+  }
+
   implicit class testableRecord[T <: Record](x: T) {
 
     /** Poke the given signal with a [[Record.litValue()]]
@@ -229,12 +281,8 @@ package object chiseltest {
       case (x: Bool, value: Bool) => x.poke(value)
       case (x: UInt, value: UInt) => x.poke(value)
       case (x: SInt, value: SInt) => x.poke(value)
-      case (x: FixedPoint, value: FixedPoint) =>
-        require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
-        pokeBits(x, value.litValue)
-      case (x: Interval, value: Interval) =>
-        require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
-        pokeBits(x, value.litValue)
+      case (x: FixedPoint, value: FixedPoint) => x.poke(value)
+      case (x: Interval, value: Interval) => x.poke(value)
       case (x: Record, value: Record) =>
         require(DataMirror.checkTypeEquivalence(x, value), s"Record type mismatch")
         x.elements.zip(value.elements).foreach { case ((_, x), (_, value)) =>
@@ -253,14 +301,11 @@ package object chiseltest {
     }
 
     def peek(): T = x match {
-      case x: Bool => x.peek().asInstanceOf[T]
-      case x: UInt => x.peek().asInstanceOf[T]
-      case x: SInt => x.peek().asInstanceOf[T]
-      case x: FixedPoint =>
-        val multiplier = BigDecimal(2).pow(x.binaryPoint.get)
-        (BigDecimal(Context().backend.peekBits(x)) / multiplier).F(x.binaryPoint).asInstanceOf[T]
-      case x: Interval =>
-        Context().backend.peekBits(x).I(x.binaryPoint).asInstanceOf[T]
+      case x: Bool       => x.peek().asInstanceOf[T]
+      case x: UInt       => x.peek().asInstanceOf[T]
+      case x: SInt       => x.peek().asInstanceOf[T]
+      case x: FixedPoint => x.peek().asInstanceOf[T]
+      case x: Interval => x.peek().asInstanceOf[T]
       case x: Record =>
         val elementValueFns = x.elements.map { case (name: String, elt: Data) =>
           (y: Record) => (y.elements(name), elt.peek())
@@ -278,12 +323,8 @@ package object chiseltest {
       case (x: Bool, value: Bool) => x.expectInternal(value.litValue, message)
       case (x: UInt, value: UInt) => x.expectInternal(value.litValue, message)
       case (x: SInt, value: SInt) => x.expectInternal(value.litValue, message)
-      case (x: FixedPoint, value: FixedPoint) =>
-        require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
-        Context().backend.expectBits(x, value.litValue, message, Some(fixedToString(x.binaryPoint)))
-      case (x: Interval, value: Interval) =>
-        require(x.binaryPoint == value.binaryPoint, "binary point mismatch")
-        Context().backend.expectBits(x, value.litValue, message, Some(fixedToString(x.binaryPoint)))
+      case (x: FixedPoint, value: FixedPoint) => x.expectInternal(value, message)
+      case (x: Interval, value: Interval) => x.expectInternal(value, message)
       case (x: Record, value: Record) =>
         require(DataMirror.checkTypeEquivalence(x, value), s"Record type mismatch")
         x.elements.zip(value.elements).foreach { case ((_, x), (_, value)) =>

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -160,7 +160,7 @@ package object chiseltest {
       case x => throw new LiteralTypeException(s"don't know how to peek $x")
     }
 
-    protected def expect(value: T, message: Option[() => String]): Unit = (x, value) match {
+    protected def expectInternal(value: T, message: Option[() => String]): Unit = (x, value) match {
       case (x: Bool, value: Bool) =>
         Context().backend.expectBits(x, value.litValue, message, Some(boolBitsToString))
       case (x: Bits, value: UInt) => Context().backend.expectBits(x, value.litValue, message, None)
@@ -174,12 +174,12 @@ package object chiseltest {
       case (x: Record, value: Record) =>
         require(DataMirror.checkTypeEquivalence(x, value), s"Record type mismatch")
         x.elements.zip(value.elements).foreach { case ((_, x), (_, value)) =>
-          x.expect(value, message)
+          x.expectInternal(value, message)
         }
       case (x: Vec[_], value: Vec[_]) =>
         require(DataMirror.checkTypeEquivalence(x, value), s"Vec type mismatch")
         x.getElements.zip(value.getElements).foreach { case (x, value) =>
-          x.expect(value, message)
+          x.expectInternal(value, message)
         }
       case (x: EnumType, value: EnumType) =>
         require(DataMirror.checkTypeEquivalence(x, value), s"EnumType mismatch")
@@ -188,8 +188,8 @@ package object chiseltest {
       // TODO: aggregate types
     }
 
-    def expect(value: T): Unit = expect(value, None)
-    def expect(value: T, message: => String): Unit = expect(value, Some(() => message))
+    def expect(value: T): Unit = expectInternal(value, None)
+    def expect(value: T, message: => String): Unit = expectInternal(value, Some(() => message))
 
     /** @return the single clock that drives the source of this signal.
       * @throws ClockResolutionException if sources of this signal have more than one, or zero clocks

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -58,8 +58,8 @@ package object chiseltest {
     def expect(value: UInt, message: => String): Unit = expectInternal(value.litValue, Some(() => message))
     def expect(value: BigInt): Unit = expectInternal(value, None)
     def expect(value: BigInt, message: => String): Unit = expectInternal(value, Some(() => message))
-    def peek():       UInt = Context().backend.peekBits(x).asUInt(DataMirror.widthOf(x))
-    def peekBigInt(): BigInt = Context().backend.peekBits(x)
+    def peek():    UInt = Context().backend.peekBits(x).asUInt(DataMirror.widthOf(x))
+    def peekInt(): BigInt = Context().backend.peekBits(x)
   }
 
   /** allows access to chisel SInt type signals with Scala native values */
@@ -77,8 +77,8 @@ package object chiseltest {
     def expect(value: SInt, message: => String): Unit = expectInternal(value.litValue, Some(() => message))
     def expect(value: BigInt): Unit = expectInternal(value, None)
     def expect(value: BigInt, message: => String): Unit = expectInternal(value, Some(() => message))
-    def peek():       SInt = Context().backend.peekBits(x).asSInt(DataMirror.widthOf(x))
-    def peekBigInt(): BigInt = Context().backend.peekBits(x)
+    def peek():    SInt = Context().backend.peekBits(x).asSInt(DataMirror.widthOf(x))
+    def peekInt(): BigInt = Context().backend.peekBits(x)
   }
 
   /** allows access to chisel Interval type signals with Scala native values */

--- a/src/test/scala/chiseltest/coverage/SimulatorCoverageTest.scala
+++ b/src/test/scala/chiseltest/coverage/SimulatorCoverageTest.scala
@@ -50,8 +50,8 @@ abstract class SimulatorCoverageTest(name: String, backend: SimulatorAnnotation,
     val rand = new scala.util.Random(0)
     val r = test(new PiEstimator).withAnnotations(noAutoCov) { dut =>
       (0 until 1000).foreach { _ =>
-        dut.x.poke(BigInt(8, rand).S)
-        dut.y.poke(BigInt(8, rand).S)
+        dut.xIn.poke(BigInt(8, rand).U)
+        dut.yIn.poke(BigInt(8, rand).U)
         dut.clock.step()
       }
     }
@@ -74,11 +74,12 @@ abstract class SimulatorCoverageTest(name: String, backend: SimulatorAnnotation,
 class TreadleCoverageTest extends SimulatorCoverageTest("Treadle", TreadleBackendAnnotation) {}
 
 private class PiEstimator extends Module {
-  val x = IO(Input(SInt(8.W)))
-  val y = IO(Input(SInt(8.W)))
+  val xIn = IO(Input(UInt(8.W)))
+  val yIn = IO(Input(UInt(8.W)))
   val inCircle = IO(Output(Bool()))
   val inRectangle = IO(Output(Bool()))
   val radius = 100
+  val (x, y) = (xIn.asSInt, yIn.asSInt)
   inCircle := (x * x + y * y) <= (radius * radius).S
   inRectangle := (x <= radius.S && x >= -radius.S) && (y <= radius.S && y >= -radius.S)
   cover(inCircle).suggestName("inCircleCover")

--- a/src/test/scala/chiseltest/tests/FixedPointTests.scala
+++ b/src/test/scala/chiseltest/tests/FixedPointTests.scala
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.tests
+
+import chisel3._
+import chisel3.experimental.FixedPoint
+import chiseltest._
+import chiseltest.simulator.RequiresVerilator
+import org.scalatest.freespec.AnyFreeSpec
+
+class FixedPointTests extends AnyFreeSpec with ChiselScalatestTester {
+  "fixed point reduce should work with BigDecimal" in {
+    test(new FixedPointReduce(FixedPoint(70.W, 60.BP), 10)) { dut =>
+      val nums = (0 until dut.size).map { _ => 0.1 }
+      nums.zipWithIndex.foreach { case (num, index) =>
+        dut.in(index).poke(num)
+      }
+      dut.clock.step()
+      val _ = dut.sum.peekBigDecimal()
+      dut.sum.expect(BigDecimal("1.000000000000000052041704279304213"))
+    }
+  }
+
+  "fixed point reduce should fail without BigDecimal" in {
+    val e = intercept[ChiselException] {
+      test(new FixedPointReduce(FixedPoint(70.W, 60.BP), 10)) { dut =>
+        val nums = (0 until dut.size).map { _ => 0.1 }
+        nums.zipWithIndex.foreach { case (num, index) =>
+          dut.in(index).poke(num)
+        }
+        dut.clock.step()
+        // The following should generate a ChiselException, losing precision trying to represent a value as a Double.
+        val _ = dut.sum.peekDouble()
+      }
+    }
+    assert(e.getMessage.contains("is too big, precision lost with > 53 bits"))
+  }
+
+  private def testFixedPointDivide(dut: FixedPointDivide): Unit = {
+    for(d <- BigDecimal(0.0) to BigDecimal(15.0) by BigDecimal(1.0 / 3.0)) {
+      dut.in.poke(d.toDouble)
+      dut.clock.step()
+      val _ = dut.out.peekDouble()
+      dut.out.expect(d.toDouble / 4.0)
+    }
+  }
+
+  "with enough bits fixed point pseudo divide should work" in {
+    test(new FixedPointDivide(FixedPoint(64.W, 32.BP), 2))(testFixedPointDivide)
+  }
+
+  "not enough bits and fixed point pseudo divide will not work" in {
+    test(new FixedPointDivide(FixedPoint(10.W, 4.BP), 2))(testFixedPointDivide)
+  }
+
+  private def testFixedIsWhole(dut: FixedIsWhole): Unit = {
+    for(i <- BigDecimal(-2.75) to BigDecimal(1.75) by 0.25) {
+      dut.in.poke(i.toDouble)
+      dut.clock.step()
+      val _ = dut.out.peek()
+      dut.out.expect(i.isWhole)
+    }
+  }
+
+  "FixedPoint width 16 succeeds on verilator" taggedAs RequiresVerilator in {
+    test(new FixedIsWhole(16)).withAnnotations(Seq(VerilatorBackendAnnotation))(testFixedIsWhole)
+  }
+
+  "FixedPoint width 15 succeeds on verilator" taggedAs RequiresVerilator in {
+    test(new FixedIsWhole(15)).withAnnotations(Seq(VerilatorBackendAnnotation))(testFixedIsWhole)
+  }
+
+  "FixedPoint width 15 succeeds on treadle" in {
+    test(new FixedIsWhole(15))(testFixedIsWhole)
+  }
+}
+
+
+/** Regression test which used to fail due to extra high bits being poked. */
+private class FixedIsWhole(w: Int) extends Module {
+  val in = IO(Input(FixedPoint(w.W, 2.BP)))
+  val out = IO(Output(Bool()))
+  val lsbsChopped = in.setBinaryPoint(0)
+  val lsbsZeroed = (lsbsChopped << 2).asFixedPoint(2.BP)
+  out := lsbsZeroed === in
+}
+
+private class FixedPointReduce(fixedType: FixedPoint, val size: Int) extends Module {
+  val in = IO(Input(Vec(size, fixedType)))
+  val sum = IO(Output(fixedType))
+  sum := in.reduce(_ + _)
+}
+
+private class FixedPointDivide(val fixedType: FixedPoint, val shiftAmount: Int) extends Module {
+  val in = IO(Input(fixedType))
+  val out = IO(Output(fixedType))
+  out := (in.asUInt >> shiftAmount).asFixedPoint(fixedType.binaryPoint)
+}

--- a/src/test/scala/chiseltest/tests/FixedPointTests.scala
+++ b/src/test/scala/chiseltest/tests/FixedPointTests.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental.FixedPoint
 import chiseltest._
 import chiseltest.simulator.RequiresVerilator
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
 
 class FixedPointTests extends AnyFreeSpec with ChiselScalatestTester {
@@ -50,7 +51,9 @@ class FixedPointTests extends AnyFreeSpec with ChiselScalatestTester {
   }
 
   "not enough bits and fixed point pseudo divide will not work" in {
-    test(new FixedPointDivide(FixedPoint(10.W, 4.BP), 2))(testFixedPointDivide)
+    assertThrows[TestFailedException] {
+      test(new FixedPointDivide(FixedPoint(10.W, 4.BP), 2))(testFixedPointDivide)
+    }
   }
 
   private def testFixedIsWhole(dut: FixedIsWhole): Unit = {

--- a/src/test/scala/chiseltest/tests/FixedPointTests.scala
+++ b/src/test/scala/chiseltest/tests/FixedPointTests.scala
@@ -99,3 +99,4 @@ private class FixedPointDivide(val fixedType: FixedPoint, val shiftAmount: Int) 
   val out = IO(Output(fixedType))
   out := (in.asUInt >> shiftAmount).asFixedPoint(fixedType.binaryPoint)
 }
+

--- a/src/test/scala/chiseltest/tests/GroundTypeTests.scala
+++ b/src/test/scala/chiseltest/tests/GroundTypeTests.scala
@@ -75,7 +75,7 @@ class GroundTypeTests extends AnyFlatSpec with ChiselScalatestTester {
     test(new PassthroughModule(UInt(4.W))) { c =>
       (0 until 16).foreach { ii =>
         c.in.poke(ii.U)
-        assert(c.out.peekBigInt() == ii)
+        assert(c.out.peekInt() == ii)
         c.clock.step()
       }
     }
@@ -85,7 +85,7 @@ class GroundTypeTests extends AnyFlatSpec with ChiselScalatestTester {
     test(new PassthroughModule(SInt(4.W))) { c =>
       (-8 to 7).foreach { ii =>
         c.in.poke(ii.S)
-        assert(c.out.peekBigInt() == ii)
+        assert(c.out.peekInt() == ii)
         c.clock.step()
       }
     }

--- a/src/test/scala/chiseltest/tests/GroundTypeTests.scala
+++ b/src/test/scala/chiseltest/tests/GroundTypeTests.scala
@@ -1,0 +1,168 @@
+package chiseltest.tests
+
+import chiseltest._
+import chisel3._
+import org.scalatest.flatspec.AnyFlatSpec
+
+
+// define the behavior of peek/poke/expect on ground type pins of the design
+class GroundTypeTests extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "chiseltest interface"
+
+  it should "allow poking UInt ports with a BigInt" in {
+    test(new PassthroughModule(UInt(4.W))) { c =>
+      (0 until 16).foreach { ii =>
+        c.in.poke(ii)
+        c.out.expect(ii.U)
+        c.clock.step()
+      }
+    }
+  }
+
+  it should "allow poking SInt ports with a BigInt" in {
+    test(new PassthroughModule(SInt(4.W))) { c =>
+      (-8 to 7).foreach { ii =>
+        c.in.poke(ii)
+        c.out.expect(ii.S)
+        c.clock.step()
+      }
+    }
+  }
+
+  it should "allow poking Bool ports with a Boolean" in {
+    test(new PassthroughModule(Bool())) { c =>
+      c.in.poke(true)
+      c.out.expect(true.B)
+      c.clock.step()
+      c.in.poke(false)
+      c.out.expect(false.B)
+      c.clock.step()
+    }
+  }
+
+  it should "allow expecting UInt ports with a BigInt" in {
+    test(new PassthroughModule(UInt(4.W))) { c =>
+      (0 until 16).foreach { ii =>
+        c.in.poke(ii.U)
+        c.out.expect(ii)
+        c.clock.step()
+      }
+    }
+  }
+
+  it should "allow expecting SInt ports with a BigInt" in {
+    test(new PassthroughModule(SInt(4.W))) { c =>
+      (-8 to 7).foreach { ii =>
+        c.in.poke(ii.S)
+        c.out.expect(ii)
+        c.clock.step()
+      }
+    }
+  }
+
+  it should "allow expecting Bool ports with a Boolean" in {
+    test(new PassthroughModule(Bool())) { c =>
+      c.in.poke(true.B)
+      c.out.expect(true)
+      c.clock.step()
+      c.in.poke(false.B)
+      c.out.expect(false)
+      c.clock.step()
+    }
+  }
+
+  it should "allow peeking UInt ports as BigInt" in {
+    test(new PassthroughModule(UInt(4.W))) { c =>
+      (0 until 16).foreach { ii =>
+        c.in.poke(ii.U)
+        assert(c.out.peekBigInt() == ii)
+        c.clock.step()
+      }
+    }
+  }
+
+  it should "allow peeking SInt ports as BigInt" in {
+    test(new PassthroughModule(SInt(4.W))) { c =>
+      (-8 to 7).foreach { ii =>
+        c.in.poke(ii.S)
+        assert(c.out.peekBigInt() == ii)
+        c.clock.step()
+      }
+    }
+  }
+
+  it should "allow peeking Booleans from bool ports" in {
+    test(new PassthroughModule(Bool())) { c =>
+      c.in.poke(true.B)
+      assert(c.out.peekBoolean())
+      c.clock.step()
+      c.in.poke(false.B)
+      assert(!c.out.peekBoolean())
+      c.clock.step()
+    }
+  }
+
+  it should "throw an error if a value is out of range: UInt(4.W) and 16" in {
+    val e = intercept[ChiselException] {
+      test(new PassthroughModule(UInt(4.W))) { c =>
+        c.in.poke(16)
+      }
+    }
+    assert(e.getMessage.contains("0 ... 15"))
+  }
+
+  it should "throw an error if a value is out of range: UInt(4.W) and -1" in {
+    val e = intercept[ChiselException] {
+      test(new PassthroughModule(UInt(4.W))) { c =>
+        c.in.poke(-1)
+      }
+    }
+    assert(e.getMessage.contains("0 ... 15"))
+  }
+
+  it should "throw an error if a value is out of range: SInt(4.W) and 8" in {
+    val e = intercept[ChiselException] {
+      test(new PassthroughModule(SInt(4.W))) { c =>
+        c.in.poke(8)
+      }
+    }
+    assert(e.getMessage.contains("-8 ... 7"))
+  }
+
+  it should "throw an error if a value is out of range: SInt(4.W) and -9" in {
+    val e = intercept[ChiselException] {
+      test(new PassthroughModule(SInt(4.W))) { c =>
+        c.in.poke(-9)
+      }
+    }
+    assert(e.getMessage.contains("-8 ... 7"))
+  }
+
+  it should "throw an error if a value is out of range: SInt(4.W) and (-9).S" in {
+    val e = intercept[ChiselException] {
+      test(new PassthroughModule(SInt(4.W))) { c =>
+        c.in.poke((-9).S)
+      }
+    }
+    assert(e.getMessage.contains("-8 ... 7"))
+  }
+
+  it should "throw an error if a value is out of range: Bool and 2" in {
+    val e = intercept[ChiselException] {
+      test(new PassthroughModule(Bool())) { c =>
+        c.in.poke(2)
+      }
+    }
+    assert(e.getMessage.contains("false/0 ... true/1"))
+  }
+
+  it should "throw an error if a value is out of range: Bool and -1" in {
+    val e = intercept[ChiselException] {
+      test(new PassthroughModule(Bool())) { c =>
+        c.in.poke(-1)
+      }
+    }
+    assert(e.getMessage.contains("false/0 ... true/1"))
+  }
+
+}

--- a/src/test/scala/chiseltest/tests/IntervalTests.scala
+++ b/src/test/scala/chiseltest/tests/IntervalTests.scala
@@ -67,3 +67,4 @@ class IntervalDivide(intervalType: Interval, val shiftAmount: Int) extends Modul
   val out = IO(Output(intervalType))
   out := (in.asUInt >> shiftAmount).asInterval(intervalType.range)
 }
+

--- a/src/test/scala/chiseltest/tests/IntervalTests.scala
+++ b/src/test/scala/chiseltest/tests/IntervalTests.scala
@@ -5,11 +5,10 @@ package chiseltest.tests
 import chisel3._
 import chisel3.experimental.Interval
 import chiseltest._
-import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class IntervalTests extends AnyFlatSpec with ChiselScalatestTester {
-  behavior of "Interval"
-  it should "interval reduce should work with BigDecimal" in {
+class IntervalTests extends AnyFreeSpec with ChiselScalatestTester {
+  "interval reduce should work with BigDecimal" in {
     test(new IntervalReduce(Interval(70.W, 60.BP), 10)) { dut =>
       val nums = (0 until dut.size).map { _ => 0.1 }
       nums.zipWithIndex.foreach { case (num, index) =>
@@ -21,7 +20,7 @@ class IntervalTests extends AnyFlatSpec with ChiselScalatestTester {
     }
   }
 
-  it should "interval reduce should fail without BigDecimal" in {
+  "interval reduce should fail without BigDecimal" in {
     val e = intercept[ChiselException] {
       test(new IntervalReduce(Interval(70.W, 60.BP), 10)) { dut =>
         val nums = (0 until dut.size).map { _ => 0.1 }
@@ -34,6 +33,23 @@ class IntervalTests extends AnyFlatSpec with ChiselScalatestTester {
       }
     }
     assert(e.getMessage.contains("is too big, precision lost with > 53 bits"))
+  }
+
+  private def testIntervalDivide(dut: IntervalDivide): Unit = {
+    for(d <- BigDecimal(0.0) to BigDecimal(15.0) by BigDecimal(1.0 / 3.0)) {
+      dut.in.poke(d.toDouble)
+      dut.clock.step()
+      val _ = dut.out.peekDouble()
+      dut.out.expect(d.toDouble / 4.0)
+    }
+  }
+
+  "with enough bits interval pseudo divide should work" in {
+    test(new IntervalDivide(Interval(64.W, 32.BP), 2)) (testIntervalDivide)
+  }
+
+  "not enough bits and interval pseudo divide will not work" in {
+    test(new IntervalDivide(Interval(10.W, 4.BP), 2)) (testIntervalDivide)
   }
 }
 

--- a/src/test/scala/chiseltest/tests/IntervalTests.scala
+++ b/src/test/scala/chiseltest/tests/IntervalTests.scala
@@ -5,6 +5,7 @@ package chiseltest.tests
 import chisel3._
 import chisel3.experimental.Interval
 import chiseltest._
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
 
 class IntervalTests extends AnyFreeSpec with ChiselScalatestTester {
@@ -49,7 +50,9 @@ class IntervalTests extends AnyFreeSpec with ChiselScalatestTester {
   }
 
   "not enough bits and interval pseudo divide will not work" in {
-    test(new IntervalDivide(Interval(10.W, 4.BP), 2)) (testIntervalDivide)
+    assertThrows[TestFailedException] {
+      test(new IntervalDivide(Interval(10.W, 4.BP), 2))(testIntervalDivide)
+    }
   }
 }
 

--- a/src/test/scala/chiseltest/tests/IntervalTests.scala
+++ b/src/test/scala/chiseltest/tests/IntervalTests.scala
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.tests
+
+import chisel3._
+import chisel3.experimental.Interval
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class IntervalTests extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "Interval"
+  it should "interval reduce should work with BigDecimal" in {
+    test(new IntervalReduce(Interval(70.W, 60.BP), 10)) { dut =>
+      val nums = (0 until dut.size).map { _ => 0.1 }
+      nums.zipWithIndex.foreach { case (num, index) =>
+        dut.in(index).poke(num)
+      }
+      dut.clock.step()
+      val _ = dut.sum.peekBigDecimal()
+      dut.sum.expect(BigDecimal("1.000000000000000052041704279304213"))
+    }
+  }
+
+  it should "interval reduce should fail without BigDecimal" in {
+    val e = intercept[ChiselException] {
+      test(new IntervalReduce(Interval(70.W, 60.BP), 10)) { dut =>
+        val nums = (0 until dut.size).map { _ => 0.1 }
+        nums.zipWithIndex.foreach { case (num, index) =>
+          dut.in(index).poke(num)
+        }
+        dut.clock.step()
+        // this should throw a ChiselException since there would be a loss of precision
+        val _ = dut.sum.peekDouble()
+      }
+    }
+    assert(e.getMessage.contains("is too big, precision lost with > 53 bits"))
+  }
+}
+
+class IntervalReduce(intervalType: Interval, val size: Int) extends Module {
+  val in = IO(Input(Vec(size, intervalType)))
+  val sum = IO(Output(intervalType))
+  sum := in.reduce(_ + _).squeeze(sum)
+}
+
+class IntervalDivide(intervalType: Interval, val shiftAmount: Int) extends Module {
+  val in = IO(Input(intervalType))
+  val out = IO(Output(intervalType))
+  out := (in.asUInt >> shiftAmount).asInterval(intervalType.range)
+}


### PR DESCRIPTION
- [x] clean up peek/poke/expect classes:
  - [x] remove unused parameter,
  - [x] use lazy eval for expect message (similar to scala assert)
  - [x] clean up IntelliJ warnings
- [x] provide scala type peek/poke/expect access for:
  - [x] Bool: Boolean, BigInt (as input only!)
  - [x] UInt: BigInt
  - [x] SInt: BigInt
  - [x] Interval: BigDecimal, Double
  - [x] FixedPoint: BigDecimal, Double
- [x] check input size (since we loosen the type restrictions, we are adding a runtime check to ensure values fit into type)
  - [x] Bool, SInt, UInt

Note: for `Interval` and `FixedPoint` I decided to just make sure that we get all the features from the old PeekPokeTester API. 