### PR TITLE
formal: test non power of two memories and fix replay bug

### DIFF
--- a/src/main/scala/chiseltest/formal/backends/Maltese.scala
+++ b/src/main/scala/chiseltest/formal/backends/Maltese.scala
@@ -150,7 +150,8 @@ private[chiseltest] object Maltese {
       case (None, value) =>
         mem = Vector.fill(depth)(value)
       case (Some(addr), value) =>
-        mem = mem.updated(addr.toInt, value)
+        // ignore out of bounds results (on the SMT level, the memory depth is always a power of two)
+        if (addr < depth) { mem = mem.updated(addr.toInt, value) }
     }
     mem
   }


### PR DESCRIPTION
This might help with https://github.com/ucb-bar/chiseltest/issues/466