### PR TITLE
Support Verilator backend on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,25 @@ jobs:
       - name: Test
         run: sbt "testOnly -- -n RequiresVerilator"
 
+  verilator-windows:
+    name: verilator regression on windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Verilator
+        run: C:\msys64\usr\bin\bash.exe -l -c "pacman -Sy --noconfirm --needed base-devel mingw-w64-x86_64-toolchain git flex mingw-w64-x86_64-cmake mingw-w64-x86_64-verilator"
+      - run: echo 'C:\msys64\usr\bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - run: echo 'C:\msys64\mingw64\bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Print Verilator Version
+        run: verilator_bin --version
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Test
+        run: sbt "testOnly -- -n RequiresVerilator"
+
   verilator:
     name: verilator regressions
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,10 +96,6 @@ jobs:
       - run: echo 'C:\msys64\mingw64\bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Print Verilator Version
         run: verilator_bin --version
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
       - name: Test
         run: sbt 'testOnly -- -n RequiresVerilator'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Print Verilator Version
         run: verilator_bin --version
       - name: Test
-        run: sbt 'testOnly -- -n RequiresVerilator'
+        run: sbt "testOnly -- -n RequiresVerilator"
 
   verilator:
     name: verilator regressions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,21 +84,6 @@ jobs:
       - name: Test
         run: sbt "testOnly -- -n RequiresVerilator"
 
-  verilator-windows:
-    name: verilator regression on windows
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Verilator
-        run: C:\msys64\usr\bin\bash.exe -l -c "pacman -Sy --noconfirm --needed base-devel mingw-w64-x86_64-toolchain git flex mingw-w64-x86_64-cmake mingw-w64-x86_64-verilator"
-      - run: echo 'C:\msys64\usr\bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - run: echo 'C:\msys64\mingw64\bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Print Verilator Version
-        run: verilator_bin --version
-      - name: Test
-        run: sbt "testOnly -- -n RequiresVerilator"
-
   verilator:
     name: verilator regressions
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           java-version: adopt@1.11
       - name: Test
-        run: sbt "testOnly -- -n RequiresVerilator"
+        run: sbt 'testOnly -- -n RequiresVerilator'
 
   verilator:
     name: verilator regressions

--- a/src/main/scala/chiseltest/simulator/BlackBox.scala
+++ b/src/main/scala/chiseltest/simulator/BlackBox.scala
@@ -1,12 +1,30 @@
 package chiseltest.simulator
 
+import chiseltest.simulator.jna.JNAUtils
+
+import java.io.{File, FileInputStream, FileOutputStream, PrintWriter}
+import scala.io.Source
+
 private object BlackBox {
 
   /** add the `.f` file containing the names of all blackbox verilog files, if it exists */
   def fFileFlags(targetDir: os.Path): Seq[String] = {
     val fFile = targetDir / firrtl.transforms.BlackBoxSourceHelper.defaultFileListName
     if (os.exists(fFile)) {
-      Seq("-f", fFile.toString())
+      if (JNAUtils.isWindows) {
+        // The canonical path on Windows contains backslashes that
+        // verilator does not recognize
+        // We need to transform backslashes to slashes
+        val windowsfFile = s"${fFile.toString()}.win"
+        val writer = new PrintWriter(windowsfFile)
+        val source = Source.fromFile(fFile.toString())
+        source.getLines().foreach(line => writer.println(line.replace("\\", "/")))
+        source.close()
+        writer.close()
+        Seq("-f", windowsfFile)
+      } else {
+        Seq("-f", fFile.toString())
+      }
     } else { Seq() }
   }
 }

--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -237,7 +237,7 @@ private object VerilatorSimulator extends Simulator {
     cFlags.mkString(" "),
     // name of the directory that verilator generates the C++ model + Makefile in
     "-Mdir",
-    s"${verilatedDir.toString()}"
+    verilatedDir.toString()
   ) ++ (if (ldFlags.nonEmpty) Seq("-LDFLAGS", ldFlags.mkString(" ")) else Seq())
 
   // documentation of Verilator flags: https://verilator.org/guide/latest/exe_verilator.html#

--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -45,7 +45,16 @@ private object VerilatorSimulator extends Simulator {
 
   // example version string: Verilator 4.038 2020-07-11 rev v4.038
   private lazy val version: (Int, Int) = { // (major, minor)
-    val versionSplitted = os.proc(if (JNAUtils.isWindows) {"verilator_bin"} else {"verilator"}, "--version").call().out.trim.split(' ')
+    val versionSplitted = os
+      .proc(
+        if (JNAUtils.isWindows) { "verilator_bin" }
+        else { "verilator" },
+        "--version"
+      )
+      .call()
+      .out
+      .trim
+      .split(' ')
     assert(
       versionSplitted.length > 1 && versionSplitted.head == "Verilator",
       s"Unknown verilator version string: ${versionSplitted.mkString(" ")}"
@@ -155,7 +164,8 @@ private object VerilatorSimulator extends Simulator {
       ret.exitCode == 0,
       s"Compilation of verilator generated code failed for circuit $topName in work dir $verilatedDir"
     )
-    val simBinary = if (JNAUtils.isWindows) {verilatedDir / s"${target}.exe"} else {verilatedDir / target}
+    val simBinary = if (JNAUtils.isWindows) { verilatedDir / s"${target}.exe" }
+    else { verilatedDir / target }
     assert(os.exists(simBinary), s"Failed to generate simulation binary: $simBinary")
     simBinary
   }
@@ -173,7 +183,13 @@ private object VerilatorSimulator extends Simulator {
     removeOldCode(verilatedDir, verbose)
     val flagAnnos = VerilatorLinkFlags(JNAUtils.ldFlags) +: VerilatorCFlags(JNAUtils.ccFlags) +: annos
     val flags = generateFlags(topName, verilatedDir, flagAnnos)
-    val cmd = List(if (JNAUtils.isWindows) {"verilator_bin"} else {"verilator"}, "--cc", "--exe", cppHarness) ++ flags ++ List(s"$topName.sv")
+    val cmd = List(
+      if (JNAUtils.isWindows) { "verilator_bin" }
+      else { "verilator" },
+      "--cc",
+      "--exe",
+      cppHarness
+    ) ++ flags ++ List(s"$topName.sv")
     val ret = run(cmd, targetDir, verbose)
 
     assert(ret.exitCode == 0, s"verilator command failed on circuit ${topName} in work dir $targetDir")

--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -45,7 +45,7 @@ private object VerilatorSimulator extends Simulator {
 
   // example version string: Verilator 4.038 2020-07-11 rev v4.038
   private lazy val version: (Int, Int) = { // (major, minor)
-    val versionSplitted = os.proc("verilator", "--version").call().out.trim.split(' ')
+    val versionSplitted = os.proc(if (JNAUtils.isWindows) {"verilator_bin"} else {"verilator"}, "--version").call().out.trim.split(' ')
     assert(
       versionSplitted.length > 1 && versionSplitted.head == "Verilator",
       s"Unknown verilator version string: ${versionSplitted.mkString(" ")}"
@@ -155,7 +155,7 @@ private object VerilatorSimulator extends Simulator {
       ret.exitCode == 0,
       s"Compilation of verilator generated code failed for circuit $topName in work dir $verilatedDir"
     )
-    val simBinary = verilatedDir / target
+    val simBinary = if (JNAUtils.isWindows) {verilatedDir / s"${target}.exe"} else {verilatedDir / target}
     assert(os.exists(simBinary), s"Failed to generate simulation binary: $simBinary")
     simBinary
   }
@@ -173,7 +173,7 @@ private object VerilatorSimulator extends Simulator {
     removeOldCode(verilatedDir, verbose)
     val flagAnnos = VerilatorLinkFlags(JNAUtils.ldFlags) +: VerilatorCFlags(JNAUtils.ccFlags) +: annos
     val flags = generateFlags(topName, verilatedDir, flagAnnos)
-    val cmd = List("verilator", "--cc", "--exe", cppHarness) ++ flags ++ List(s"$topName.sv")
+    val cmd = List(if (JNAUtils.isWindows) {"verilator_bin"} else {"verilator"}, "--cc", "--exe", cppHarness) ++ flags ++ List(s"$topName.sv")
     val ret = run(cmd, targetDir, verbose)
 
     assert(ret.exitCode == 0, s"verilator command failed on circuit ${topName} in work dir $targetDir")
@@ -221,7 +221,7 @@ private object VerilatorSimulator extends Simulator {
     cFlags.mkString(" "),
     // name of the directory that verilator generates the C++ model + Makefile in
     "-Mdir",
-    verilatedDir.toString()
+    s"${verilatedDir.toString()}"
   ) ++ (if (ldFlags.nonEmpty) Seq("-LDFLAGS", ldFlags.mkString(" ")) else Seq())
 
   // documentation of Verilator flags: https://verilator.org/guide/latest/exe_verilator.html#

--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -87,7 +87,9 @@ private object VerilatorSimulator extends Simulator {
     val targetDir = Compiler.requireTargetDir(state.annotations)
     val toplevel = TopmoduleInfo(state.circuit)
 
-    val libPath = targetDir / "verilated" / ("V" + toplevel.name)
+    val libFilename = if (JNAUtils.isWindows) { "V" + toplevel.name + ".exe" }
+    else { "V" + toplevel.name }
+    val libPath = targetDir / "verilated" / libFilename
     // the binary we created communicates using our standard IPC interface
     val coverageAnnos = loadCoverageAnnos(targetDir)
     val coverageFile = targetDir / "coverage.dat"

--- a/src/main/scala/chiseltest/simulator/jna/JNAUtils.scala
+++ b/src/main/scala/chiseltest/simulator/jna/JNAUtils.scala
@@ -16,8 +16,8 @@ object JNAUtils {
     "win32"
   } else {
     System.getProperty("os.name") match {
-      case "Mac OS X"   => "darwin"
-      case "Linux"      => "linux"
+      case "Mac OS X" => "darwin"
+      case "Linux"    => "linux"
       case s: String => s
     }
   }

--- a/src/main/scala/chiseltest/simulator/jna/JNAUtils.scala
+++ b/src/main/scala/chiseltest/simulator/jna/JNAUtils.scala
@@ -18,7 +18,6 @@ object JNAUtils {
     System.getProperty("os.name") match {
       case "Mac OS X"   => "darwin"
       case "Linux"      => "linux"
-      case "Windows 10" => "win32"
       case s: String => s
     }
   }

--- a/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala
@@ -149,7 +149,7 @@ struct sim_state {
 
 static sim_state* create_sim_state() {
   sim_state *s = new sim_state();
-  std::string dumpfile = "${vcdFilePath}";
+  std::string dumpfile = R"(${vcdFilePath})";
   _startCoverageAndDump(&s->tfp, dumpfile, s->dut);
   return s;
 }
@@ -291,7 +291,7 @@ static sim_state* create_sim_state() {
                          |  delete tfp;
                          |#endif
                          |#if VM_COVERAGE
-                         |  VerilatedCov::write("$targetDir/coverage.dat");
+                         |  VerilatedCov::write(R"($targetDir/coverage.dat)");
                          |#endif
                          |  top->final();
                          |  // TODO: re-enable!

--- a/src/test/scala/chiseltest/simulator/Verilator.scala
+++ b/src/test/scala/chiseltest/simulator/Verilator.scala
@@ -2,6 +2,7 @@
 
 package chiseltest.simulator
 
+import chiseltest.simulator.jna.JNAUtils
 import chiseltest.utils.CaptureStdout
 import org.scalatest.Tag
 import chiseltest.utils.FlatSpecWithTargetDir
@@ -18,7 +19,7 @@ class VerilatorMemoryCompliance extends MemoryCompliance(VerilatorSimulator, Req
 class VerilatorStopAssertAssumeCompliance extends StopAssertAssumeCompliance(VerilatorSimulator, RequiresVerilator)
 
 class VerilatorSpecificTests extends FlatSpecWithTargetDir {
-  behavior of "verilator"
+  behavior.of("verilator")
 
   private val sim = VerilatorSimulator
 
@@ -40,7 +41,9 @@ class VerilatorSpecificTests extends FlatSpecWithTargetDir {
       assert(dut.peek("io_out") == 1)
       dut.finish()
     }
-    assert(out.contains("verilator --cc --exe "))
+    val verilatorBinName = if (JNAUtils.isWindows) { "verilator_bin" }
+    else { "verilator" }
+    assert(out.contains(s"${verilatorBinName} --cc --exe "))
     assert(out.contains("g++"))
     assert(out.contains("perl"))
     assert(out.contains("make -C"))


### PR DESCRIPTION
According to [Spinal HDL documentation](https://spinalhdl.github.io/SpinalDoc-RTD/dev/SpinalHDL/Simulation/install/Verilator.html), Verilator can be used on Windows via MSYS2. But the executable on Windows is `verilator_bin` (see [here](https://github.com/SpinalHDL/SpinalHDL/blob/8631157de28920e6e50854a62f15aaebf52adc62/sim/src/main/scala/spinal/sim/VerilatorBackend.scala#L477)), we need to check the OS to get the correct name.