### PR TITLE
rename getStep to getStepCount

### DIFF
--- a/src/main/scala/chiseltest/internal/BackendInterface.scala
+++ b/src/main/scala/chiseltest/internal/BackendInterface.scala
@@ -68,7 +68,7 @@ trait BackendInterface {
   /** Returns the current step, i.e., the number of clock cycles performed by the test so far,
     * excluding any initial reset cycles performed by the chiseltest library at the start of the test.
     */
-  def getStep(signal: Clock): Long
+  def getStepCount(signal: Clock): Long
 
   def doFork(runnable: () => Unit, name: Option[String], region: Option[Region]): AbstractTesterThread
 

--- a/src/main/scala/chiseltest/internal/GenericBackend.scala
+++ b/src/main/scala/chiseltest/internal/GenericBackend.scala
@@ -127,7 +127,7 @@ class GenericBackend[T <: Module](
     }
   }
 
-  override def getStep(signal: Clock): Long = {
+  override def getStepCount(signal: Clock): Long = {
     require(signal == dut.clock, "step count is only implemented for a single clock right now")
     stepCount
   }

--- a/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
+++ b/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
@@ -97,7 +97,7 @@ class SingleThreadBackend[T <: Module](
 
   private var stepCount: Long = 0
 
-  override def getStep(signal: Clock): Long = {
+  override def getStepCount(signal: Clock): Long = {
     require(signal == dut.clock)
     stepCount
   }

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -518,8 +518,8 @@ package object chiseltest {
     /** Returns the current step, i.e., the number of clock cycles performed by the test so far,
       * excluding any initial reset cycles performed by the chiseltest library at the start of the test.
       */
-    def getStep: Long = {
-      Context().backend.getStep(x)
+    def getStepCount: Long = {
+      Context().backend.getStepCount(x)
     }
   }
 

--- a/src/test/scala/chiseltest/tests/GetStepCountTest.scala
+++ b/src/test/scala/chiseltest/tests/GetStepCountTest.scala
@@ -9,15 +9,15 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 
 
-class GetStepTest extends AnyFlatSpec with ChiselScalatestTester {
+class GetStepCountTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 clock getStep"
 
   private def runTest(c: StaticModule[_]): Unit = {
-    assert(c.clock.getStep == 0)
+    assert(c.clock.getStepCount == 0)
     c.clock.step()
-    assert(c.clock.getStep == 1)
+    assert(c.clock.getStepCount == 1)
     c.clock.step(10)
-    assert(c.clock.getStep == 11)
+    assert(c.clock.getStepCount == 11)
   }
 
   it should "check steps in single clock" in {
@@ -34,7 +34,7 @@ class GetStepTest extends AnyFlatSpec with ChiselScalatestTester {
       val delta = rand.nextInt(3) + 1
       c.clock.step(delta)
       count += delta
-      assert(c.clock.getStep == count)
+      assert(c.clock.getStepCount == count)
     }
   }
 


### PR DESCRIPTION
I want to see what other people think. Personally I have developed a fairly strong preference for naming the functionality `getStepCount` instead of `getStep` in order to make it more clear what it is doing.