### PR TITLE
Fix build.sc to avoid testFrameworks

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -36,6 +36,11 @@ class chiseltestCrossModule(val crossScalaVersion: String)
     )
   else Agg.empty[Dep]
 
+  def chisel3PluginIvyDeps = if (chisel3Module.isEmpty) {
+    Agg(ivy"edu.berkeley.cs:::chisel3-plugin:${defaultVersions("chisel3")}")
+  }
+  else Agg.empty[Dep]
+
   def treadleModule: Option[PublishModule] = None
 
   def treadleIvyDeps = if (treadleModule.isEmpty)
@@ -73,20 +78,18 @@ class chiseltestCrossModule(val crossScalaVersion: String)
     ) ++ chisel3IvyDeps ++ treadleIvyDeps
   }
 
-  object test extends Tests with ScalafmtModule {
-    override def ivyDeps = T {
-      Agg(
-        ivy"org.scalatest::scalatest:3.0.8",
-        ivy"com.lihaoyi::utest:0.7.11"
-      ) ++ chisel3IvyDeps ++ treadleIvyDeps
-    }
+  override def scalacPluginIvyDeps = T { chisel3PluginIvyDeps }
 
-    def testFrameworks = T {
-      Seq(
-        "org.scalatest.tools.Framework",
-        "utest.runner.Framework"
-      )
-    }
+  def test = T {
+    T.sequence(Seq(test_1.test(), test_2.test()))
+  }
+
+  object test_1 extends Tests with TestModule.ScalaTest with ScalafmtModule {
+    override def ivyDeps = T { chisel3IvyDeps ++ treadleIvyDeps }
+  }
+
+  object test_2 extends Tests with TestModule.Utest with ScalafmtModule {
+    override def ivyDeps = T { chisel3IvyDeps ++ treadleIvyDeps }
   }
 
   def pomSettings = T {


### PR DESCRIPTION
Begin from mill-0.9.7, testFrameworks targets is deperecated, which
cause 'mill bloopInstall' fail to run.

some logs from .metals/metals.log befor this fix:
```
2022.03.25 19:43:09 INFO  [463/1252] chiseltestCrossModule.test.testFramework
2022.03.25 19:43:09 INFO  1 targets failed
2022.03.25 19:43:09 INFO  chiseltestCrossModule.test.testFramework Since mill after-0.9.6 only one test framework per TestModule is supported. Target testFrameworks is deprecated. Please use target testFramework or use on of the predefined TestModules: TestNg, Junit, Scalatest, ...
2022.03.25 19:43:10 INFO  time: ran 'mill bloopInstall' in 10m1s
2022.03.25 19:43:10 ERROR Mill command failed: /tmp/metals17868073092207274821/millw --mill-version 0.9.9 --predef /tmp/metals17868073092207274821/predef.sc mill.contrib.Bloop/install

```