### PR TITLE
[GenericBackend] Add `UnpeekableException` if signal not found

### DIFF
--- a/src/main/scala/chiseltest/exceptions.scala
+++ b/src/main/scala/chiseltest/exceptions.scala
@@ -5,6 +5,7 @@ package chiseltest
 class NotLiteralException(message: String) extends Exception(message)
 class LiteralTypeException(message: String) extends Exception(message)
 class UnpokeableException(message: String) extends Exception(message)
+class UnpeekableException(message: String) extends Exception(message)
 class UnsupportedOperationException(message: String) extends Exception(message)
 
 class ClockResolutionException(message: String) extends Exception(message)

--- a/src/main/scala/chiseltest/internal/GenericBackend.scala
+++ b/src/main/scala/chiseltest/internal/GenericBackend.scala
@@ -2,7 +2,14 @@
 
 package chiseltest.internal
 
-import chiseltest.{ChiselAssertionError, ClockResolutionException, Region, StopException, TimeoutException}
+import chiseltest.{
+  ChiselAssertionError,
+  ClockResolutionException,
+  Region,
+  StopException,
+  TimeoutException,
+  UnpeekableException
+}
 import chisel3._
 import chiseltest.coverage.TestCoverage
 import chiseltest.simulator.{SimulatorContext, StepInterrupted, StepOk}
@@ -74,6 +81,11 @@ class GenericBackend[T <: Module](
 
   override def peekBits(signal: Data): BigInt = {
     doPeek(signal, new Throwable)
+    if (!dataNames.keySet.exists(_ == signal)) {
+      throw new UnpeekableException(
+        "Signal not found. Perhaps you're peeking a non-IO signal.\n  If so, consider using the chiseltest.experimental.expose API."
+      )
+    }
     val a = tester.peek(dataNames(signal))
     debugLog(s"${resolveName(signal)} -> $a")
     a

--- a/src/main/scala/chiseltest/internal/GenericBackend.scala
+++ b/src/main/scala/chiseltest/internal/GenericBackend.scala
@@ -2,14 +2,7 @@
 
 package chiseltest.internal
 
-import chiseltest.{
-  ChiselAssertionError,
-  ClockResolutionException,
-  Region,
-  StopException,
-  TimeoutException,
-  UnpeekableException
-}
+import chiseltest._
 import chisel3._
 import chiseltest.coverage.TestCoverage
 import chiseltest.simulator.{SimulatorContext, StepInterrupted, StepOk}
@@ -81,13 +74,14 @@ class GenericBackend[T <: Module](
 
   override def peekBits(signal: Data): BigInt = {
     doPeek(signal, new Throwable)
-    if (!dataNames.keySet.exists(_ == signal)) {
+    val name = dataNames.getOrElse(
+      signal,
       throw new UnpeekableException(
-        "Signal not found. Perhaps you're peeking a non-IO signal.\n  If so, consider using the chiseltest.experimental.expose API."
+        s"Signal $signal not found. Perhaps you're peeking a non-IO signal.\n  If so, consider using the chiseltest.experimental.expose API."
       )
-    }
-    val a = tester.peek(dataNames(signal))
-    debugLog(s"${resolveName(signal)} -> $a")
+    )
+    val a = tester.peek(name)
+    debugLog(s"$name -> $a")
     a
   }
 

--- a/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
+++ b/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
@@ -1,14 +1,7 @@
 package chiseltest.internal
 
 import chisel3.{Clock, Data, Module}
-import chiseltest.{
-  ChiselAssertionError,
-  ClockResolutionException,
-  Region,
-  StopException,
-  TimeoutException,
-  UnpeekableException
-}
+import chiseltest._
 import chiseltest.coverage.TestCoverage
 import chiseltest.simulator.{SimulatorContext, StepInterrupted, StepOk}
 import firrtl.AnnotationSeq
@@ -60,13 +53,13 @@ class SingleThreadBackend[T <: Module](
   }
 
   override def peekBits(signal: Data): BigInt = {
-    if (!dataNames.keySet.exists(_ == signal)) {
+    val name = dataNames.getOrElse(
+      signal,
       throw new UnpeekableException(
-        "Signal not found. Perhaps you're peeking a non-IO signal.\n  If so, consider using the chiseltest.experimental.expose API."
+        s"Signal $signal not found. Perhaps you're peeking a non-IO signal.\n  If so, consider using the chiseltest.experimental.expose API."
       )
-    }
-    val a = tester.peek(dataNames(signal))
-    a
+    )
+    tester.peek(name)
   }
 
   override def doTimescope(contents: () => Unit): Unit = {

--- a/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
+++ b/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
@@ -1,7 +1,14 @@
 package chiseltest.internal
 
 import chisel3.{Clock, Data, Module}
-import chiseltest.{ChiselAssertionError, ClockResolutionException, Region, StopException, TimeoutException}
+import chiseltest.{
+  ChiselAssertionError,
+  ClockResolutionException,
+  Region,
+  StopException,
+  TimeoutException,
+  UnpeekableException
+}
 import chiseltest.coverage.TestCoverage
 import chiseltest.simulator.{SimulatorContext, StepInterrupted, StepOk}
 import firrtl.AnnotationSeq
@@ -53,6 +60,11 @@ class SingleThreadBackend[T <: Module](
   }
 
   override def peekBits(signal: Data): BigInt = {
+    if (!dataNames.keySet.exists(_ == signal)) {
+      throw new UnpeekableException(
+        "Signal not found. Perhaps you're peeking a non-IO signal.\n  If so, consider using the chiseltest.experimental.expose API."
+      )
+    }
     val a = tester.peek(dataNames(signal))
     a
   }

--- a/src/test/scala/chiseltest/tests/BasicTest.scala
+++ b/src/test/scala/chiseltest/tests/BasicTest.scala
@@ -28,13 +28,25 @@ class BasicTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   }
 
   it should "fail on peeking internal signals" in {
-    assertThrows[UnpeekableException] {
+    val e = intercept[UnpeekableException] {
       test(new Module {
         val hidden = Reg(Bool())
       }) { c =>
         c.hidden.peek()
       }
     }
+    assert(e.getMessage.contains("hidden"))
+  }
+
+  it should "fail on peeking internal signals with single threaded backend" in {
+    val e = intercept[UnpeekableException] {
+      test(new Module {
+        val hidden = Reg(Bool())
+      }).withAnnotations(Seq(chiseltest.internal.NoThreadingAnnotation)) { c =>
+        c.hidden.peek()
+      }
+    }
+    assert(e.getMessage.contains("hidden"))
   }
 
   it should "fail on expect mismatch" in {

--- a/src/test/scala/chiseltest/tests/BasicTest.scala
+++ b/src/test/scala/chiseltest/tests/BasicTest.scala
@@ -27,6 +27,16 @@ class BasicTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
     }
   }
 
+  it should "fail on peeking internal signals" in {
+    assertThrows[UnpeekableException] {
+      test(new Module {
+        val hidden = Reg(Bool())
+      }) { c =>
+        c.hidden.peek()
+      }
+    }
+  }
+
   it should "fail on expect mismatch" in {
     assertThrows[exceptions.TestFailedException] {
       test(new StaticModule(42.U)) { c =>


### PR DESCRIPTION
For Modules with internal signals when the `GenericBackend` goes to peek, the signal will not be found.  This results in a slightly unintuitive `java.util.NoSuchElementException`.

```scala
class dummy extends Module {
  val unseen = Reg(UInt(6.W))
  unseen := 42.U
}
```
The following test on the above Module throws java.util.NoSuchElementException: key not found exception
```scala
     test(new dummy) { c =>
        c.unseen.expect(42.U)
     }

```

The proposal is to add an `UnpeekableException` which suggests the user use `chiseltest.experimental.expose`. 


The exception message now reads:
```sh
[info]  chiseltest.UnpeekableException: Signal not found. Perhaps you're peeking a non-IO signal. 
[info]  If so, consider using the chiseltest.experimental.expose API.
```

---
As an aside:
- The repetitive code makes me think `BackendExecutive`, `package` or a parent class should handle checking for this as it's possible other Backends would still have this issue. 