### PR TITLE
added +plusarg support for Icarus

### DIFF
--- a/src/main/scala/chiseltest/simulator/IcarusSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/IcarusSimulator.scala
@@ -44,12 +44,11 @@ private object IcarusSimulator extends Simulator {
   }
   private def majorVersion: Int = version._1
   private def minorVersion: Int = version._2
-  
-  
+
   private def getSimulatorArgs(state: CircuitState): Array[String] = {
     state.annotations.view.collect { case PlusArgsAnnotation(args) => args }.flatten.toArray
   }
-  
+
   /** start a new simulation
     *
     * @param state LoFirrtl circuit + annotations

--- a/src/main/scala/chiseltest/simulator/IcarusSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/IcarusSimulator.scala
@@ -44,7 +44,12 @@ private object IcarusSimulator extends Simulator {
   }
   private def majorVersion: Int = version._1
   private def minorVersion: Int = version._2
-
+  
+  
+  private def getSimulatorArgs(state: CircuitState): Array[String] = {
+    state.annotations.view.collect { case PlusArgsAnnotation(args) => args }.flatten.toArray
+  }
+  
   /** start a new simulation
     *
     * @param state LoFirrtl circuit + annotations
@@ -75,7 +80,8 @@ private object IcarusSimulator extends Simulator {
 
     // turn SystemVerilog into simulation binary
     val simCmd = compileSimulation(toplevel.name, targetDir, verilogHarness) ++
-      waveformFlags(targetDir, toplevel.name, state.annotations)
+      waveformFlags(targetDir, toplevel.name, state.annotations) ++
+      getSimulatorArgs(state)
 
     // the binary we created communicates using our standard IPC interface
     new IPCSimulatorContext(simCmd, toplevel, IcarusSimulator)

--- a/src/test/scala/chiseltest/backends/icarus/IcarusBlackBoxTest.scala
+++ b/src/test/scala/chiseltest/backends/icarus/IcarusBlackBoxTest.scala
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.backends.icarus
+
+import chisel3._
+import chisel3.util._
+import chiseltest._
+import chiseltest.simulator.{PlusArgsAnnotation, RequiresIcarus}
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.util.Random
+
+class BlackBoxAdderIO extends Bundle {
+  val a = Input(UInt(8.W))
+  val b = Input(UInt(8.W))
+  val q = Output(UInt(8.W))
+}
+
+class BlackBoxAdder extends BlackBox with HasBlackBoxInline {
+  val io = IO(new BlackBoxAdderIO).suggestName("io")
+  setInline("BlackBoxAdder.v",
+  """module BlackBoxAdder(a, b, q);
+    |input [7:0] a, b;
+    |output [7:0] q;
+    |assign q = a + b;
+    |endmodule
+    |""".stripMargin)
+}
+
+class BlackBoxAdderWrapper extends Module {
+  val io = IO(new BlackBoxAdderIO)
+  val m = Module(new BlackBoxAdder)
+  m.io <> io
+}
+
+// Inspired by plusarg_reader in rocket-chip
+class PlusArgReader extends BlackBox with HasBlackBoxInline {
+  val io = IO(new Bundle {
+    val out = Output(UInt(32.W))
+  })
+  setInline("PlusArgReader.v",
+  """module PlusArgReader(
+    |  output [31:0] out
+    |);
+    |  reg [32:0] argument;
+    |  assign out = argument;
+    |  initial begin
+    |    if (!$value$plusargs("ARGUMENT=%d", argument)) begin
+    |      argument = 32'hdeadbeef;
+    |    end
+    |  end
+    |endmodule
+    |""".stripMargin)
+}
+
+class PlusArgReaderWrapper(expected: Int) extends Module {
+  val reader = Module(new PlusArgReader)
+  assert(reader.io.out === expected.U, s"Expected $expected, got %x.\n", reader.io.out)
+}
+
+class IcarusBlackBoxTests extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "Icarus Backend"
+
+  val annos = Seq(IcarusBackendAnnotation)
+
+  it should "support IcarusVerilog black boxes" taggedAs RequiresIcarus in {
+    val rand = new Random()
+    val mask = (BigInt(1) << 8) - 1
+    test(new BlackBoxAdderWrapper).withAnnotations(annos) { dut =>
+      (0 until 1000).foreach { ii =>
+        val a = BigInt(8, rand)
+        val b = BigInt(8, rand)
+        val q = (a + b) & mask
+        dut.io.a.poke(a.U)
+        dut.io.b.poke(b.U)
+        dut.io.q.expect(q.U)
+      }
+    }
+  }
+
+  it should "support reading IcarusVerilog plusargs" taggedAs RequiresIcarus in {
+    for (plusarg <- List(0, 123, 456)) {
+      val allAnnos = annos :+ PlusArgsAnnotation(s"+ARGUMENT=$plusarg" :: Nil)
+      test(new PlusArgReaderWrapper(plusarg)).withAnnotations(allAnnos) { dut =>
+        dut.reset.poke(true.B)
+        dut.clock.step()
+        dut.reset.poke(false.B)
+        dut.clock.step()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Leveraged the existing work for the Verilator `+plusarg` support to also extend to Icarus Verilog. I don't currently have a VCS license on my personal machine, so I don't have a way to validate VCS. Will see if I can add the same to VCS.

Added an Icarus Verilog test which will test the `+plusarg` functionality. This is also a clone of the `VerilogBlackBoxTest` that is used for Verilator.