### PR TITLE
Fix verilator time

### DIFF
--- a/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala
@@ -240,8 +240,9 @@ static sim_state* create_sim_state() {
                          |}
                          |
                          |
-                         |// required for asserts (until Verilator 4.200)
-                         |double sc_time_stamp () { return 0; }
+                         |// Global because older versions of verilator do not support contexts
+                         |static vluint64_t global_time = 0;
+                         |double sc_time_stamp () { return global_time; }
                          |
                          |static void _startCoverageAndDump(VERILATED_C** tfp, const std::string& dumpfile, TOP_CLASS* top) {
                          |$coverageInit
@@ -258,12 +259,14 @@ static sim_state* create_sim_state() {
                          |
                          |static int64_t _step(VERILATED_C* tfp, TOP_CLASS* top, vluint64_t& main_time) {
                          |    $clockLow
+                         |    global_time = main_time;
                          |    top->eval();
                          |#if VM_TRACE
                          |    if (tfp) tfp->dump(main_time);
                          |#endif
                          |    main_time++;
                          |    $clockHigh
+                         |    global_time = main_time;
                          |    top->eval();
                          |#if VM_TRACE
                          |    if (tfp) tfp->dump(main_time);

--- a/src/test/scala/chiseltest/backends/icarus/IcarusTimeTaskTest.scala
+++ b/src/test/scala/chiseltest/backends/icarus/IcarusTimeTaskTest.scala
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.backends.icarus
+
+import chisel3._
+import chisel3.util._
+import chiseltest._
+import chiseltest.simulator.RequiresIcarus
+import org.scalatest.flatspec.AnyFlatSpec
+
+class IcarusTimeTaskTest extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "Icarus backend"
+
+  val annos = Seq(IcarusBackendAnnotation)
+
+  it should "support BlackBoxes that invoke the Verilog $time task" taggedAs RequiresIcarus in {
+    class BlackBoxTime extends BlackBox with HasBlackBoxInline {
+      val io = IO(new Bundle {
+        val clock = Input(Clock())
+        val out = Output(UInt(64.W))
+      })
+      setInline(s"${this.name}.v",
+      s"""module ${this.name}(
+         |  input clock,
+         |  output reg [63:0] out
+         |);
+         |  always @(posedge clock) begin
+         |    out <= $$time;
+         |  end
+         |endmodule
+         |""".stripMargin)
+    }
+
+    test(new Module {
+      val out = IO(Output(UInt(64.W)))
+      val inst = Module(new BlackBoxTime)
+      inst.io.clock := clock
+      out := inst.io.out
+      }).withAnnotations(annos) { c =>
+      // Check that time increments, each clock edge is counts as 1 so a step is 2
+      val start = c.out.peek.litValue
+      c.clock.step()
+      assert(c.out.peek.litValue == start + 2)
+      c.clock.step()
+      assert(c.out.peek.litValue == start + 4)
+      c.clock.step()
+      assert(c.out.peek.litValue == start + 6)
+      c.clock.step()
+      assert(c.out.peek.litValue == start + 8)
+    }
+  }
+}

--- a/src/test/scala/chiseltest/backends/verilator/VerilatorTimeTaskTest.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilatorTimeTaskTest.scala
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.backends.verilator
+
+import chisel3._
+import chisel3.util._
+import chiseltest._
+import chiseltest.simulator.RequiresVerilator
+import org.scalatest.flatspec.AnyFlatSpec
+
+class VerilatorTimeTaskTest extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "Verilator backend"
+
+  val annos = Seq(VerilatorBackendAnnotation)
+
+  it should "support BlackBoxes that invoke the Verilog $time task" taggedAs RequiresVerilator in {
+    class BlackBoxTime extends BlackBox with HasBlackBoxInline {
+      val io = IO(new Bundle {
+        val clock = Input(Clock())
+        val out = Output(UInt(64.W))
+      })
+      setInline(s"${this.name}.v",
+      s"""module ${this.name}(
+         |  input clock,
+         |  output reg [63:0] out
+         |);
+         |  always @(posedge clock) begin
+         |    out <= $$time;
+         |  end
+         |endmodule
+         |""".stripMargin)
+    }
+
+    test(new Module {
+      val out = IO(Output(UInt(64.W)))
+      val inst = Module(new BlackBoxTime)
+      inst.io.clock := clock
+      out := inst.io.out
+      }).withAnnotations(annos) { c =>
+      // Check that time increments, each clock edge is counts as 1 so a step is 2
+      val start = c.out.peek.litValue
+      c.clock.step()
+      assert(c.out.peek.litValue == start + 2)
+      c.clock.step()
+      assert(c.out.peek.litValue == start + 4)
+      c.clock.step()
+      assert(c.out.peek.litValue == start + 6)
+      c.clock.step()
+      assert(c.out.peek.litValue == start + 8)
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/ucb-bar/chiseltest/issues/538

h/t @terpstra for the bug report and fix

I'm not sure how this happens but you can see my comment in the test about some really bizarre behavior that made writing this test take forever. Basically I originally had:
```scala
  behavior of "Verilator backend"
```
When running the test it would correctly generate Verilog and invoke Verilator to create a simulation binary, but `c.out` always returned `0` no matter what I did and any assertions or printfs inside the design were ignored. Merely changing the String "Verilator backend" to anything else fixed the issue.

I feel like I'm taking crazy pills but maybe there's some crazy interaction going on in the ScalaTest harness.