### PR TITLE
Verilator make with fixed number of jobs

### DIFF
--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -160,7 +160,8 @@ private object VerilatorSimulator extends Simulator {
 
   private def compileSimulation(topName: String, verilatedDir: os.Path, verbose: Boolean): os.Path = {
     val target = s"V$topName"
-    val cmd = Seq("make", "-C", verilatedDir.toString(), "-j", "-f", s"V$topName.mk", target)
+    val processorCount = Runtime.getRuntime.availableProcessors.toString
+    val cmd = Seq("make", "-C", verilatedDir.toString(), "-j", processorCount, "-f", s"V$topName.mk", target)
     val ret = run(cmd, null, verbose)
     assert(
       ret.exitCode == 0,


### PR DESCRIPTION
This will change varilator make to run on a fixed number of jobs. Specificly the number of cores in the computer.

From the `make` manual,
> If the -j option is given without an argument, make  will  not  limit the number of jobs that can run simultaneously.

This behavior was causing my computer to swap a lot.