### PR TITLE
Fix vcs assertions

### DIFF
--- a/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
@@ -24,7 +24,7 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
 
     val codeBuffer = new StringBuilder
     codeBuffer.append(s"module $testbenchName;\n")
-    codeBuffer.append(s"  reg $clockName = 1;\n")
+    codeBuffer.append(s"  reg $clockName = 0;\n")
     toplevel.inputs.foreach { case PinInfo(name, width, _) =>
       codeBuffer.append(s"  reg[${width - 1}:0] $name = 0;\n")
     }


### PR DESCRIPTION
The 'reset' signal cannot glitch from 0 to 1 at power on.
If it does, then all the assertions in a vcs design will fire.
