### PR TITLE
VCS Q-2020.03 (at least) fails because it can't find nullptr

### DIFF
--- a/src/main/resources/simulator/vpi.h
+++ b/src/main/resources/simulator/vpi.h
@@ -32,7 +32,7 @@ public:
     vpiHandle syscall_handle = vpi_handle(vpiSysTfCall, NULL);
     vpiHandle arg_iter = vpi_iterate(vpiArgument, syscall_handle);
     // Cache Inputs
-    if(arg_iter != nullptr) {
+    if(arg_iter != NULL) {
       while (vpiHandle arg_handle = vpi_scan(arg_iter)) {
         sim_data.inputs.push_back(arg_handle);
       }
@@ -43,7 +43,7 @@ public:
     vpiHandle syscall_handle = vpi_handle(vpiSysTfCall, NULL);
     vpiHandle arg_iter = vpi_iterate(vpiArgument, syscall_handle);
     // Cache Outputs
-    if(arg_iter != nullptr) {
+    if(arg_iter != NULL) {
       while (vpiHandle arg_handle = vpi_scan(arg_iter)) {
         sim_data.outputs.push_back(arg_handle);
       }


### PR DESCRIPTION
VCS (version Q-2020.03) integration with chiseltest fails with a compiler error when compiling vpi.cpp. It seems that `nullptr` is not defined. Everywhere else, `NULL` seems to be used for the same thing. I made that change and now all my tests in [chisel-pla](https://github.com/stevenmburns/chisel-pla) work with `treadle`, `verilator` and now `vcs`.
I don't know your testing strategy for VCS because it is not an open source tool. Let me know if you would like me to run any tests on `main` against these changes.