### PR TITLE
Remove quotes around VcsCFlags

### DIFF
--- a/src/main/resources/simulator/vpi.h
+++ b/src/main/resources/simulator/vpi.h
@@ -32,7 +32,7 @@ public:
     vpiHandle syscall_handle = vpi_handle(vpiSysTfCall, NULL);
     vpiHandle arg_iter = vpi_iterate(vpiArgument, syscall_handle);
     // Cache Inputs
-    if(arg_iter != NULL) {
+    if(arg_iter != nullptr) {
       while (vpiHandle arg_handle = vpi_scan(arg_iter)) {
         sim_data.inputs.push_back(arg_handle);
       }
@@ -43,7 +43,7 @@ public:
     vpiHandle syscall_handle = vpi_handle(vpiSysTfCall, NULL);
     vpiHandle arg_iter = vpi_iterate(vpiArgument, syscall_handle);
     // Cache Outputs
-    if(arg_iter != NULL) {
+    if(arg_iter != nullptr) {
       while (vpiHandle arg_handle = vpi_scan(arg_iter)) {
         sim_data.outputs.push_back(arg_handle);
       }

--- a/src/main/scala/chiseltest/simulator/VcsSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VcsSimulator.scala
@@ -158,7 +158,6 @@ private object VcsSimulator extends Simulator {
     // combine all flags
     val userFlags = annos.collectFirst { case VcsFlags(f) => f }.getOrElse(Seq.empty)
     val flags = DefaultFlags(topName, cFlags, verdiFlags) ++ userFlags
-
     flags
   }
 

--- a/src/main/scala/chiseltest/simulator/VcsSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VcsSimulator.scala
@@ -158,6 +158,7 @@ private object VcsSimulator extends Simulator {
     // combine all flags
     val userFlags = annos.collectFirst { case VcsFlags(f) => f }.getOrElse(Seq.empty)
     val flags = DefaultFlags(topName, cFlags, verdiFlags) ++ userFlags
+
     flags
   }
 
@@ -193,7 +194,7 @@ private object VcsSimulator extends Simulator {
     "-LDFLAGS",
     "-lstdc++",
     "-CFLAGS",
-    "\"" + cFlags.mkString(" ") + "\""
+    cFlags.mkString(" ") // Don't wrap in double quotes
   ) ++ verdiFlags
 
   private def generateHarness(


### PR DESCRIPTION
This is the real fix for the issue addressed in PR #572 
The reason for the `nullptr` not being found compiler error was that the `-std=c++11` flag was not being seen by an older compiler (gcc 4.8.5). What was actually being run was the command line:
```
g++ -w  -pipe -fPIC "-ICS_HOME/include -I/nfs/site/disks/scl.work.50/ash/users/smburns/chisel-examples/test_run_dir/Alu_should_pass_AluSpec_tests -fPIC -std=c++11" -O -I/p/hdk/rtl/cad/x86-64_linux44/synopsys/vcsmx/Q-2020.03/include    -c ../vpi.cpp
```
The double quotes around the command line options in the middle meant that they were not being treated separately, and silently then `-std=c+11` options was being ignored.
The proposed fix corrects this issue, and we can leave the `nullptr` usages in the `vpi.h` file.
Also, the `VcsCFlags` annotation will to work, allowing new C compiler flags to be added as necessary by the user.