### PR TITLE
remove verilator on mac test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,25 +65,6 @@ jobs:
       - name: Test
         run: sbt ++${{ matrix.scala }} "testOnly -- -n RequiresIcarus"
 
-  verilator-mac:
-    name: verilator regression on mac
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install Tabby OSS Cad Suite (from YosysHQ)
-        uses: YosysHQ/setup-oss-cad-suite@v1
-        with:
-          osscadsuite-version: '2022-08-18'
-      - name: Print Verilator Version
-        run: verilator --version
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-      - name: Test
-        run: sbt "testOnly -- -n RequiresVerilator"
-
   verilator:
     name: verilator regressions
     runs-on: ubuntu-20.04
@@ -193,7 +174,7 @@ jobs:
   # When adding new jobs, please add them to `needs` below
   all_tests_passed:
     name: "all tests passed"
-    needs: [test, doc, verilator, verilator-mac, formal, formal-mac, icarus, test-mac]
+    needs: [test, doc, verilator, formal, formal-mac, icarus, test-mac]
     runs-on: ubuntu-latest
     steps:
       - run: echo Success!


### PR DESCRIPTION
The Tabby CAD action tends to fail more often than succeed on Mac and there is no bug that we have ever caught with this test.