### PR TITLE
Delay first rising clock edge by 1 half-period in VPI Harness

### DIFF
--- a/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
@@ -32,7 +32,12 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
       codeBuffer.append(s"  wire[${width - 1}:0] $name;\n")
     }
 
-    codeBuffer.append(s"  always #`CLOCK_PERIOD $clockName = ~$clockName;\n")
+    codeBuffer.append(s"  initial begin\n")
+    codeBuffer.append(s"    #`CLOCK_PERIOD; // Delay first clock edge to avoid race condition with randomization\n")
+    codeBuffer.append(s"    forever begin\n")
+    codeBuffer.append(s"      #`CLOCK_PERIOD $clockName = ~$clockName;\n")
+    codeBuffer.append(s"    end\n")
+    codeBuffer.append(s"  end\n")
     codeBuffer.append(s"  reg [4095:0] $dumpFileVar = 0;\n")
     codeBuffer.append(s"  reg $dumpOnVar = 0;\n") // this is a hack to exclude the first half-cycle from the wave dump
 


### PR DESCRIPTION
This prevents a race condition between the rising clock edge and randomization when RANDOMIZE_DELAY=1. Note that the traditional Chisel randomization delay of #0.002 is based on VCS's default timescale of 1ns/1ps and does not properly work with other timescales. It is much safer to use a full timescale delay, and thus prudent to delay the first rising clock edge till the 2nd time step.

Note that this does change waveforms slightly such that you have a full clock period with no clock before it starts rather than the first rising edge being after merely half a clock-period. See `old` and `new` (except of course there is no zero-time falling edge, I can't figure out how to get rid of it in Wavedrom)

![Screen Shot 2022-12-22 at 2 37 45 PM](https://user-images.githubusercontent.com/8584418/209237307-786ef190-3f63-4f8c-ba54-a45b0dc3d32f.png)
