### PR TITLE
Remove Icarus debug messages

### DIFF
--- a/src/main/scala/chiseltest/simulator/VcsSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VcsSimulator.scala
@@ -96,8 +96,11 @@ private object VcsSimulator extends Simulator {
       userSimFlags ++
       waveformFlags(targetDir, toplevel.name, state.annotations)
 
+    // show verbose debug messages
+    val verbose = state.annotations.contains(SimulatorDebugAnnotation)
+
     // the binary we created communicates using our standard IPC interface
-    new IPCSimulatorContext(simCmd, toplevel, VcsSimulator)
+    new IPCSimulatorContext(simCmd, toplevel, VcsSimulator, verbose)
   }
 
   private def waveformFlags(targetDir: os.Path, topName: String, annos: AnnotationSeq): Seq[String] = {

--- a/src/test/scala/chiseltest/simulator/BasicCompliance.scala
+++ b/src/test/scala/chiseltest/simulator/BasicCompliance.scala
@@ -139,10 +139,6 @@ abstract class BasicCompliance(sim: Simulator, tag: Tag = DefaultTag, skipSimRef
   }
 
   it should "not print anything to stdout under normal conditions" taggedAs(tag) in {
-    // TODO: icarus and vcs still print out some spam in non-debug mode
-    val isIcarusOrVcs = sim == IcarusSimulator || sim == VcsSimulator
-    assume(!isIcarusOrVcs)
-
     val (_, out) = CaptureStdout {
       val dut = load(standardCircuit)
       dut.poke("io_in", 1)

--- a/src/test/scala/chiseltest/simulator/PeekPokeCompliance.scala
+++ b/src/test/scala/chiseltest/simulator/PeekPokeCompliance.scala
@@ -91,6 +91,7 @@ abstract class PeekPokeCompliance(sim: Simulator, tag: Tag = DefaultTag) extends
       if(res != values) { dut.finish() }
       assert(res == values, s"width = $w")
     }
+    dut.finish()
   }
 
   it should "propagate SInt values of variable widths through the circuit" taggedAs(tag) in {
@@ -115,6 +116,7 @@ abstract class PeekPokeCompliance(sim: Simulator, tag: Tag = DefaultTag) extends
       if(res != values) { dut.finish() }
       assert(res == values, s"width = $w")
     }
+    dut.finish()
   }
 
 }


### PR DESCRIPTION
When using Icarus backend there was many debug messages that was not needed. I changed it to not output anything normally but show debug messages when `SimulatorDebugAnnotation` is set, like the Verilator backend.

By the way I found that some tests in `PeekPokeCompliance` had not properly finished the dut. it was causing the simulator to keep running after the test finished.