### PR TITLE
vcs: fix vpd generation (#18)

### DIFF
--- a/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
@@ -60,7 +60,6 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
       codeBuffer.append("    /*** Enable VPD dump ***/\n")
       codeBuffer.append("    if ($value$plusargs(\"vcdplusfile=%s\", " + dumpFileVar + ")) begin\n")
       codeBuffer.append(s"      $$vcdplusfile($dumpFileVar);\n")
-      codeBuffer.append(s"      $$dumpfile($dumpFileVar);\n")
       codeBuffer.append(s"      $$dumpvars(0, $dutName);\n")
       codeBuffer.append(s"      $$vcdpluson;\n")
       codeBuffer.append("    end\n")


### PR DESCRIPTION
dumpfile produces a vcd output.
The previous code wrote two streams into the same file.

Replaces https://github.com/ucb-bar/chiseltest/pull/604