### PR TITLE
chiseltest: eliminate dump file annotations

### DIFF
--- a/src/main/scala/chiseltest/simulator/Compiler.scala
+++ b/src/main/scala/chiseltest/simulator/Compiler.scala
@@ -64,7 +64,8 @@ private[chiseltest] object Compiler {
   }
   private def isInternalAnno(a: Annotation): Boolean = a match {
     case _: FirrtlCircuitAnnotation | _: DesignAnnotation[_] | _: ChiselCircuitAnnotation | _: DeletedAnnotation |
-        _: EmittedCircuitAnnotation[_] | _: LogLevelAnnotation =>
+        _: EmittedCircuitAnnotation[_] | _: LogLevelAnnotation |
+        WriteVcdAnnotation | WriteFsdbAnnotation | WriteVpdAnnotation =>
       true
     case _ => false
   }


### PR DESCRIPTION
I'm not 100% sure this is the correct fix on main.
In our private branch, WriteVpdAnnotation was missing which caused circt to fail complaining about the annotation.
In main, I don't see ANY of the annotations being filtered, though.

So maybe this is no longer necessary?