### PR TITLE
FIX: remove treadleModule in build.sc

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -58,7 +58,7 @@ class chiseltestCrossModule(val crossScalaVersion: String)
     super.javacOptions() ++ Seq("-source", "1.8", "-target", "1.8")
   }
 
-  override def moduleDeps = super.moduleDeps ++ chisel3Module ++ treadleModule
+  override def moduleDeps = super.moduleDeps ++ chisel3Module
 
   override def ivyDeps = T {
     Agg(


### PR DESCRIPTION
As treadle source code is imported in https://github.com/ucb-bar/chiseltest/commit/a6b1091f66bf58f37855093b314d3d73dae12f23, `treadleModule` should be removed in `build.sc`.