### PR TITLE
Replace getDataNames with DataMirror.fullModulePorts

### DIFF
--- a/src/main/scala/chiseltest/internal/BackendExecutive.scala
+++ b/src/main/scala/chiseltest/internal/BackendExecutive.scala
@@ -23,7 +23,7 @@ object BackendExecutive {
     val (highFirrtl, dut) = Compiler.elaborate(dutGen, testersAnnotationSeq, chiselAnnos)
 
     // extract port names
-    val portNames = DataMirror.modulePorts(dut).flatMap { case (name, data) => getDataNames(name, data).toList }.toMap
+    val portNames = DataMirror.fullModulePorts(dut).map(_.swap).toMap
 
     // compile to low firrtl
     val lowFirrtl = Compiler.toLowFirrtl(highFirrtl)
@@ -54,15 +54,6 @@ object BackendExecutive {
   }
 
   private def componentToName(component: ReferenceTarget): String = component.name
-
-  /** Returns a Seq of (data reference, fully qualified element names) for the input.
-    * name is the name of data
-    */
-  private def getDataNames(name: String, data: Data): Seq[(Data, String)] = Seq(data -> name) ++ (data match {
-    case _: Element => Seq()
-    case b: Record  => b.elements.toSeq.flatMap { case (n, e) => getDataNames(s"${name}_$n", e) }
-    case v: Vec[_]  => v.zipWithIndex.flatMap { case (e, i) => getDataNames(s"${name}_$i", e) }
-  })
 
   /** This creates some kind of map of combinational paths between inputs and outputs.
     *

--- a/src/test/scala/chiseltest/tests/OpaqueTypeTest.scala
+++ b/src/test/scala/chiseltest/tests/OpaqueTypeTest.scala
@@ -1,0 +1,39 @@
+package chiseltest.tests
+
+import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
+import chisel3.experimental.OpaqueType
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.collection.immutable.SeqMap
+
+class OpaqueTypeTest extends AnyFlatSpec with ChiselScalatestTester {
+
+  class OpaqueRecord[T <: Data](val data: T) extends Record with OpaqueType {
+    val elements: SeqMap[String, T] = SeqMap("" -> data)
+  }
+
+  class OpaquePassthrough[T <: Data](data: T) extends Module {
+    val in: OpaqueRecord[T] = IO(Input(new OpaqueRecord(data)))
+    val out: OpaqueRecord[T] = IO(Output(new OpaqueRecord(data)))
+    out := in
+  }
+
+  def rec[T <: Data](_val: => T): OpaqueRecord[T] = new OpaqueRecord(_val.cloneType: T).Lit(_.data -> _val)
+
+  def testPokeExpect[T <: Data](_val: => T): TestResult =
+    test(new OpaquePassthrough(_val.cloneType)) { dut =>
+      dut.in.poke(rec(_val))
+      dut.out.expect(rec(_val))
+    }
+
+  behavior of "OpaqueType"
+
+  it should "poke and expect successfully" in {
+    testPokeExpect(4.U(6.W))
+    testPokeExpect(-4.S(8.W))
+    testPokeExpect(rec(5.U(3.W)))
+  }
+
+}

--- a/src/test/scala/chiseltest/tests/OpaqueTypeTest.scala
+++ b/src/test/scala/chiseltest/tests/OpaqueTypeTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor


### PR DESCRIPTION
Addresses #661.

* Remove `getDataNames`
* Add test with `Record` extending `OpaqueType`