### PR TITLE
Replace getDataNames with DataMirror.fullModulePorts (backport to 0.6.x)

### DIFF
--- a/src/main/scala/chiseltest/internal/BackendExecutive.scala
+++ b/src/main/scala/chiseltest/internal/BackendExecutive.scala
@@ -19,7 +19,7 @@ object BackendExecutive {
     val (highFirrtl, dut) = Compiler.elaborate(dutGen, testersAnnotationSeq)
 
     // extract port names
-    val portNames = DataMirror.modulePorts(dut).flatMap { case (name, data) => getDataNames(name, data).toList }.toMap
+    val portNames = DataMirror.fullModulePorts(dut).map(_.swap).toMap
 
     // compile to low firrtl
     val lowFirrtl = Compiler.toLowFirrtl(highFirrtl)

--- a/src/test/scala/chiseltest/formal/examples/VGBComparisonOfFormalAndSimulation.scala
+++ b/src/test/scala/chiseltest/formal/examples/VGBComparisonOfFormalAndSimulation.scala
@@ -236,7 +236,7 @@ class ShapeProcessor extends Module {
     value === 1.U || value === 2.U || value === 4.U
   }
   def isLegalOperation(value: UInt): Bool =
-    MuxLookup(value(6,4), false.B, Seq(
+    MuxLookup(value(6,4), false.B)(Seq(
       0.U -> (value(3,0) <= 1.U),
       2.U -> (value(3,0) === 0.U),
       4.U -> (value(3,0) <= 1.U),

--- a/src/test/scala/chiseltest/iotesters/examples/ALUTester.scala
+++ b/src/test/scala/chiseltest/iotesters/examples/ALUTester.scala
@@ -36,7 +36,7 @@ class ALU extends Module {
 
   private val mux_alu_opcode = io.alu_opcode(AluOpCode.length - 1, 0)
 
-  io.out := MuxLookup(mux_alu_opcode, "hDEADF00D".U,
+  io.out := MuxLookup(mux_alu_opcode, "hDEADF00D".U)(
     Seq(
       AluOpCode.Add -> (io.in1 + io.in2),
       AluOpCode.Sub -> (io.in1 - io.in2),

--- a/src/test/scala/chiseltest/tests/OpaqueTypeTest.scala
+++ b/src/test/scala/chiseltest/tests/OpaqueTypeTest.scala
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.tests
+
+import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
+import chisel3.experimental.OpaqueType
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.collection.immutable.SeqMap
+
+class OpaqueTypeTest extends AnyFlatSpec with ChiselScalatestTester {
+
+  class OpaqueRecord[T <: Data](val data: T) extends Record with OpaqueType {
+    val elements: SeqMap[String, T] = SeqMap("" -> data)
+  }
+
+  class OpaquePassthrough[T <: Data](data: T) extends Module {
+    val in: OpaqueRecord[T] = IO(Input(new OpaqueRecord(data)))
+    val out: OpaqueRecord[T] = IO(Output(new OpaqueRecord(data)))
+    out := in
+  }
+
+  def rec[T <: Data](_val: => T): OpaqueRecord[T] = new OpaqueRecord(_val.cloneType: T).Lit(_.data -> _val)
+
+  def testPokeExpect[T <: Data](_val: => T): TestResult =
+    test(new OpaquePassthrough(_val.cloneType)) { dut =>
+      dut.in.poke(rec(_val))
+      dut.out.expect(rec(_val))
+    }
+
+  behavior of "OpaqueType"
+
+  it should "poke and expect successfully" in {
+    testPokeExpect(4.U(6.W))
+    testPokeExpect(-4.S(8.W))
+    testPokeExpect(rec(5.U(3.W)))
+  }
+
+}


### PR DESCRIPTION
Backports #662 to 0.6.x.

* Remove getDataNames
* Add test with Record extending OpaqueType