### PR TITLE
Replace getDataNames with DataMirror.fullModulePorts in PeekPokeTester (backport to 0.6.x)

### DIFF
--- a/src/main/scala/chiseltest/internal/PeekPokeTesterBackend.scala
+++ b/src/main/scala/chiseltest/internal/PeekPokeTesterBackend.scala
@@ -23,7 +23,7 @@ object PeekPokeTesterBackend {
   def run[T <: Module](dutGen: () => T, testerGen: T => PeekPokeTester[T], annos: AnnotationSeq): AnnotationSeq = {
     val (sim, covAnnos, dut) = createTester(dutGen, defaults.addDefaultSimulator(annos))
     // extract port names
-    val portNames = DataMirror.modulePorts(dut).flatMap { case (name, data) => getDataNames(name, data).toList }.toMap
+    val portNames = DataMirror.fullModulePorts(dut).map(_.swap).toMap
     val localCtx = IOTestersContext(sim, portNames)
 
     // run tests
@@ -42,13 +42,6 @@ object PeekPokeTesterBackend {
     // if we get here we were successful!
     finish(sim, covAnnos)
   }
-
-  /** Returns a Seq of (data reference, fully qualified element names) for the input. name is the name of data. */
-  private def getDataNames(name: String, data: Data): Seq[(Data, String)] = Seq(data -> name) ++ (data match {
-    case _: Element => Seq()
-    case b: Record  => b.elements.toSeq.flatMap { case (n, e) => getDataNames(s"${name}_$n", e) }
-    case v: Vec[_]  => v.zipWithIndex.flatMap { case (e, i) => getDataNames(s"${name}_$i", e) }
-  })
 
 }
 

--- a/src/test/scala/chiseltest/tests/OpaqueTypeTest.scala
+++ b/src/test/scala/chiseltest/tests/OpaqueTypeTest.scala
@@ -6,6 +6,7 @@ import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 import chisel3.experimental.OpaqueType
 import chisel3._
 import chiseltest._
+import chiseltest.iotesters.PeekPokeTester
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.collection.immutable.SeqMap
@@ -30,12 +31,27 @@ class OpaqueTypeTest extends AnyFlatSpec with ChiselScalatestTester {
       dut.out.expect(rec(_val))
     }
 
+  class PokeExpectTester[T <: Data](dut: OpaquePassthrough[T], _val: => T) extends PeekPokeTester(dut) {
+    poke(dut.in, IndexedSeq(_val.litValue))
+    expect(dut.out, IndexedSeq(_val.litValue))
+  }
+
+  def testPokeExpectTester[T <: Data](_val: => T): Unit =
+    test(new OpaquePassthrough(_val.cloneType))
+      .runPeekPoke(new PokeExpectTester(_, _val))
+
   behavior of "OpaqueType"
 
   it should "poke and expect successfully" in {
     testPokeExpect(4.U(6.W))
     testPokeExpect(-4.S(8.W))
     testPokeExpect(rec(5.U(3.W)))
+  }
+
+  it should "poke and expect successfully using PeekPokeTester" in {
+    testPokeExpectTester(4.U(6.W))
+    testPokeExpectTester(-4.S(8.W))
+    testPokeExpectTester(rec(5.U(3.W)))
   }
 
 }


### PR DESCRIPTION
Addresses #661.
Backports #667 to 0.6.x branch.