### PR TITLE
Bugfix: loadMemoryFromFile support absolute paths

### DIFF
--- a/src/main/scala/treadle2/executable/Memory.scala
+++ b/src/main/scala/treadle2/executable/Memory.scala
@@ -653,7 +653,7 @@ class MemoryInitializer(engine: ExecutionEngine) extends LazyLogging {
 private object MemoryFileParser {
   def parse(filename: String, base: Int): Seq[BigInt] = {
     require(base == 16 || base == 2)
-    val fullName = os.Path(filename, base=os.pwd)
+    val fullName = os.Path(filename, base = os.pwd)
     os.read.lines(fullName).flatMap(l => parseLine(l.trim, base))
   }
   private def parseLine(line: String, base: Int): Seq[BigInt] = {

--- a/src/main/scala/treadle2/executable/Memory.scala
+++ b/src/main/scala/treadle2/executable/Memory.scala
@@ -653,7 +653,7 @@ class MemoryInitializer(engine: ExecutionEngine) extends LazyLogging {
 private object MemoryFileParser {
   def parse(filename: String, base: Int): Seq[BigInt] = {
     require(base == 16 || base == 2)
-    val fullName = os.pwd / os.RelPath(filename)
+    val fullName = os.Path(filename, base=os.pwd)
     os.read.lines(fullName).flatMap(l => parseLine(l.trim, base))
   }
   private def parseLine(line: String, base: Int): Seq[BigInt] = {

--- a/src/test/scala/chiseltest/iotesters/examples/LoadMemoryFromFileSpec.scala
+++ b/src/test/scala/chiseltest/iotesters/examples/LoadMemoryFromFileSpec.scala
@@ -29,7 +29,7 @@ class UsesMem(memoryDepth: Int, memoryType: Bits, fileName: String) extends Modu
   io.value2 := low.io.value
 }
 object UsesMem {
-  val MEM1 = "src/test/resources/iotesters/mem1.txt"
+  val Mem1 = "src/test/resources/iotesters/mem1.txt"
 }
 
 class UsesMemLow(memoryDepth: Int, memoryType: Data) extends Module {
@@ -66,14 +66,14 @@ class LoadMemoryFromFileSpec extends AnyFreeSpec with ChiselScalatestTester {
 
   "Treadle supports loadFromFileInline using absolute paths" in {
     // An absolute path
-    val path: os.Path = os.pwd / os.RelPath(UsesMem.MEM1)
+    val path: os.Path = os.pwd / os.RelPath(UsesMem.Mem1)
     test(new UsesMem(memoryDepth = 8, memoryType = UInt(16.W), path.toString()))
       .runPeekPoke(new LoadMemoryFromFileTester(_))
   }
 
   "Treadle also supports loadFromFileInline using relative paths" in {
     // An absolute path
-    test(new UsesMem(memoryDepth = 8, memoryType = UInt(16.W), UsesMem.MEM1))
+    test(new UsesMem(memoryDepth = 8, memoryType = UInt(16.W), UsesMem.Mem1))
       .runPeekPoke(new LoadMemoryFromFileTester(_))
   }
 }

--- a/src/test/scala/chiseltest/iotesters/examples/LoadMemoryFromFileSpec.scala
+++ b/src/test/scala/chiseltest/iotesters/examples/LoadMemoryFromFileSpec.scala
@@ -3,9 +3,9 @@
 package chiseltest.iotesters.examples
 
 import chisel3._
-import chiseltest.iotesters._
 import chisel3.util.experimental.loadMemoryFromFileInline
 import chiseltest._
+import chiseltest.iotesters._
 import chiseltest.simulator.RequiresVerilator
 import firrtl2.options.TargetDirAnnotation
 import org.scalatest.freespec.AnyFreeSpec

--- a/src/test/scala/chiseltest/iotesters/examples/LoadMemoryFromFileSpec.scala
+++ b/src/test/scala/chiseltest/iotesters/examples/LoadMemoryFromFileSpec.scala
@@ -10,7 +10,7 @@ import chiseltest.simulator.RequiresVerilator
 import firrtl2.options.TargetDirAnnotation
 import org.scalatest.freespec.AnyFreeSpec
 
-class UsesMem(memoryDepth: Int, memoryType: Bits) extends Module {
+class UsesMem(memoryDepth: Int, memoryType: Bits, fileName: String) extends Module {
   val io = IO(new Bundle {
     val address = Input(UInt(memoryType.getWidth.W))
     val value = Output(memoryType)
@@ -19,7 +19,7 @@ class UsesMem(memoryDepth: Int, memoryType: Bits) extends Module {
 
   val memory = Mem(memoryDepth, memoryType)
 
-  loadMemoryFromFileInline(memory, "src/test/resources/iotesters/mem1.txt")
+  loadMemoryFromFileInline(memory, fileName)
 
   io.value := memory(io.address)
 
@@ -27,6 +27,9 @@ class UsesMem(memoryDepth: Int, memoryType: Bits) extends Module {
 
   low.io.address := io.address
   io.value2 := low.io.value
+}
+object UsesMem {
+  val MEM1 = "src/test/resources/iotesters/mem1.txt"
 }
 
 class UsesMemLow(memoryDepth: Int, memoryType: Data) extends Module {
@@ -56,8 +59,21 @@ class LoadMemoryFromFileSpec extends AnyFreeSpec with ChiselScalatestTester {
   "Users can specify a source file to load memory from" taggedAs RequiresVerilator in {
 
     val targetDir = TargetDirAnnotation("test_run_dir/load_mem_test")
-    test(new UsesMem(memoryDepth = 8, memoryType = UInt(16.W)))
+    test(new UsesMem(memoryDepth = 8, memoryType = UInt(16.W), "src/test/resources/iotesters/mem1.txt"))
       .withAnnotations(Seq(VerilatorBackendAnnotation, targetDir))
+      .runPeekPoke(new LoadMemoryFromFileTester(_))
+  }
+
+  "Treadle supports loadFromFileInline using absolute paths" in {
+    // An absolute path
+    val path: os.Path = os.pwd / os.RelPath(UsesMem.MEM1)
+    test(new UsesMem(memoryDepth = 8, memoryType = UInt(16.W), path.toString()))
+      .runPeekPoke(new LoadMemoryFromFileTester(_))
+  }
+
+  "Treadle also supports loadFromFileInline using relative paths" in {
+    // An absolute path
+    test(new UsesMem(memoryDepth = 8, memoryType = UInt(16.W), UsesMem.MEM1))
       .runPeekPoke(new LoadMemoryFromFileTester(_))
   }
 }


### PR DESCRIPTION
Previously, specifying an absolute path in loadMemoryFromFileInline would cause an error when running with treadle, because the path was absolutized using os.path.RelPath. The latter function throws an exception for absolute paths.

Now both absolute and relative paths work (matching the behaviour of Verilator).

Note that this has no security implications, since the previous "relative-path" based implementation also allowed "../../" paths; existing relative paths should not be affected.