### PR TITLE
Add pono backend to chisel formal for bmc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        backend: [z3, cvc4, btormc, bitwuzla]
+        backend: [z3, cvc4, btormc, bitwuzla, pono]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/src/main/scala/chiseltest/formal/backends/Maltese.scala
+++ b/src/main/scala/chiseltest/formal/backends/Maltese.scala
@@ -2,7 +2,7 @@
 
 package chiseltest.formal.backends
 
-import chiseltest.formal.backends.btor.BtormcModelChecker
+import chiseltest.formal.backends.btor._
 import chiseltest.formal.backends.smt._
 import chiseltest.formal.{DoNotModelUndef, DoNotOptimizeFormal, FailedBoundedCheckException}
 import firrtl2._
@@ -55,6 +55,8 @@ private case object BoolectorEngineAnnotation extends FormalEngineAnnotation
   *   bitwuzla often performs better than Z3 or CVC4.
   */
 case object BitwuzlaEngineAnnotation extends FormalEngineAnnotation
+
+case object PonoEngineAnnotation extends FormalEngineAnnotation
 
 /** Formal Verification based on the firrtl compiler's SMT backend and the maltese SMT libraries solver bindings. */
 private[chiseltest] object Maltese {
@@ -166,10 +168,11 @@ private[chiseltest] object Maltese {
     engines.map {
       case CVC4EngineAnnotation      => new SMTModelChecker(CVC4SMTLib)
       case Z3EngineAnnotation        => new SMTModelChecker(Z3SMTLib)
-      case BtormcEngineAnnotation    => new BtormcModelChecker(targetDir)
+      case BtormcEngineAnnotation    => new Btor2ModelChecker(BtormcBtor2, targetDir)
       case Yices2EngineAnnotation    => new SMTModelChecker(Yices2SMTLib)
       case BoolectorEngineAnnotation => new SMTModelChecker(BoolectorSMTLib)
       case BitwuzlaEngineAnnotation  => new SMTModelChecker(BitwuzlaSMTLib)
+      case PonoEngineAnnotation      => new Btor2ModelChecker(PonoBtor2, targetDir)
     }
   }
 

--- a/src/main/scala/chiseltest/formal/package.scala
+++ b/src/main/scala/chiseltest/formal/package.scala
@@ -8,5 +8,6 @@ package object formal {
   val Z3EngineAnnotation = backends.Z3EngineAnnotation
   val BtormcEngineAnnotation = backends.BtormcEngineAnnotation
   val BitwuzlaEngineAnnotation = backends.BitwuzlaEngineAnnotation
+  val PonoEngineAnnotation = backends.PonoEngineAnnotation
   val MagicPacketTracker = vips.MagicPacketTracker
 }

--- a/src/test/scala/chiseltest/formal/FormalBackendOption.scala
+++ b/src/test/scala/chiseltest/formal/FormalBackendOption.scala
@@ -17,6 +17,7 @@ object FormalBackendOption {
       case Some("z3")        => Z3EngineAnnotation
       case Some("cvc4")      => CVC4EngineAnnotation
       case Some("btormc")    => BtormcEngineAnnotation
+      case Some("pono")      => PonoEngineAnnotation
       case Some("yices2")    => throw new RuntimeException("yices is not supported yet")
       case Some("boolector") => throw new RuntimeException("boolector is not supported yet")
       case Some("bitwuzla")  => BitwuzlaEngineAnnotation


### PR DESCRIPTION
The code is fairly straightforward as much of the existing btor code can be reused. The only real difference between the two btor2 backends is their command line invocation.

----

From here, it should be trivial to add k-induction as one will only need to change the engine from `bmc` to `ind` when running `pono`.

---

# Testing

I've run the [Keepmax](https://github.com/ucb-bar/chiseltest/blob/main/src/test/scala/chiseltest/formal/examples/KeepMax.scala) tests on the `pono` engine as well as `btormc` and they both succeed. I have also verified that upon editing `KeepMax` to fail, a counterexample is generated by both engines.