### PR TITLE
Bump to chisel 6 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,9 +91,10 @@ jobs:
         # 4.034: Chipyard
         # 4.038: Ubuntu 20.10
         # 4.108: Fedora 34
-        # 4.200: currently the latest version on brew (MacOS)
         # 4.202: added "forcePerInstance" to support our coverage flow
-        version: ["4.028", "4.032", "4.034", "4.038", "4.108", "4.200", "4.202"]
+        # 5.018: currently the latest version on brew (macOS)
+        # 5.020: latest release
+        version: ["4.028", "4.032", "4.034", "4.038", "4.108", "4.200", "4.202", "5.018", "5.020"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,9 +92,9 @@ jobs:
         # 4.038: Ubuntu 20.10
         # 4.108: Fedora 34
         # 4.202: added "forcePerInstance" to support our coverage flow
-        # 5.018: currently the latest version on brew (macOS)
-        # 5.020: latest release
-        version: ["4.028", "4.032", "4.034", "4.038", "4.108", "4.200", "4.202", "5.018", "5.020"]
+        # 5.018: current version on Homebrew (5/2/2024)
+        # 5.020: latest release (5/2/2024)
+        version: ["4.028", "4.032", "4.034", "4.038", "4.108", "4.200", "4.202"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala: [ 2.13.10 ]
-        jvm: [ 8, 11, 20 ]
+        scala: [ 2.13.12 ]
+        jvm: [ 8, 11, 20, 21 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,10 +83,10 @@ jobs:
 
   verilator:
     name: verilator regressions
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # 4.028: Ubuntu 20.04, Fedora 32
+        # 4.028: Ubuntu 22.04, Fedora 32
         # 4.032: Fedora 33
         # 4.034: Chipyard
         # 4.038: Ubuntu 20.10
@@ -95,12 +95,11 @@ jobs:
         # 5.018: currently the latest version on brew (macOS)
         # 5.020: latest release
         version: ["4.028", "4.032", "4.034", "4.038", "4.108", "4.200", "4.202", "5.018", "5.020"]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Verilator Build Dependencies
-        run: sudo apt-get install -y git make autoconf g++ flex bison libfl2 libfl-dev
+        run: sudo apt-get install -y git make autoconf g++ flex bison libfl2 libfl-dev help2man
       - name: Cache Verilator ${{ matrix.version }}
         uses: actions/cache@v3
         id: cache-verilator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
 
   verilator:
     name: verilator regressions
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # 4.028: Ubuntu 22.04, Fedora 32

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val chiseltestSettings = Seq(
     "org.chipsalliance" %% "chisel" % chiselVersion,
     "edu.berkeley.cs" %% "firrtl2" % firrtlVersion,
     "org.scalatest" %% "scalatest" % "3.2.17",
-    "net.java.dev.jna" % "jna" % "5.13.0",
+    "net.java.dev.jna" % "jna" % "5.14.0",
     compilerPlugin(("org.chipsalliance" % "chisel-plugin" % chiselVersion).cross(CrossVersion.full))
   ),
   resolvers ++= Resolver.sonatypeOssRepos("snapshots"),

--- a/build.sbt
+++ b/build.sbt
@@ -2,20 +2,21 @@
 
 lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
-  scalaVersion := "2.13.10",
-  crossScalaVersions := Seq("2.13.10")
+  scalaVersion := "2.13.12",
+  crossScalaVersions := Seq("2.13.12")
 )
 
-val chiselVersion = "6.0.0-M3"
+val chiselVersion = "6.0.0"
 val firrtlVersion = "6.0-SNAPSHOT"
 
 lazy val chiseltestSettings = Seq(
   name := "chiseltest",
   // we keep in sync with chisel version names
-  version := "6.0-SNAPSHOT",
+  version := "6.0.0",
   scalacOptions := Seq(
     "-deprecation",
     "-feature",
+    "-Xcheckinit",
     "-language:reflectiveCalls",
     // do not warn about firrtl imports, once the firrtl repo is removed, we will need to import the code
     "-Wconf:cat=deprecation&msg=Importing from firrtl is deprecated:s",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")

--- a/src/main/scala/chiseltest/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chiseltest/iotesters/PeekPokeTester.scala
@@ -112,9 +112,9 @@ abstract class PeekPokeTester[T <: Module](val dut: T) extends LazyLogging {
   private def maskedBigInt(bigInt: BigInt, width: Int): BigInt = bigInt & ((BigInt(1) << width) - 1)
 
   // helps us work around the fact that signal.width is private!
-  private def getFirrtlWidth(signal: Bits): chisel3.internal.firrtl.Width = signal.widthOption match {
-    case Some(value) => chisel3.internal.firrtl.KnownWidth(value)
-    case None        => chisel3.internal.firrtl.UnknownWidth()
+  private def getFirrtlWidth(signal: Bits): chisel3.Width = signal.widthOption match {
+    case Some(value) => chisel3.KnownWidth(value)
+    case None        => chisel3.UnknownWidth()
   }
 
   /** Locate a specific bundle element, given a name path. TODO: Handle Vecs

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -324,9 +324,9 @@ package object chiseltest {
     }
 
     // helps us work around the fact that signal.width is private!
-    def getFirrtlWidth(signal: Bits): chisel3.internal.firrtl.Width = signal.widthOption match {
-      case Some(value) => chisel3.internal.firrtl.KnownWidth(value)
-      case None        => chisel3.internal.firrtl.UnknownWidth()
+    def getFirrtlWidth(signal: Bits): chisel3.Width = signal.widthOption match {
+      case Some(value) => chisel3.KnownWidth(value)
+      case None        => chisel3.UnknownWidth()
     }
 
     def boolBitsToString(bits: BigInt): String = (bits != 0).toString

--- a/src/main/scala/chiseltest/simulator/ChiselBridge.scala
+++ b/src/main/scala/chiseltest/simulator/ChiselBridge.scala
@@ -154,8 +154,12 @@ private object ChiselBridge {
     // ignoreDecodeTableAnnotation since it is not needed by the firrtl compiler
     case _: DecodeTableAnnotation => None
     //
-    case _ => Some(UnsupportedAnnotation(anno.getClass.getSimpleName, anno.toString))
-    // case _ => throw new NotImplementedError(s"TODO: convert ${anno}")
+    case _ =>
+      println(
+        s"[WARNING] Unsupported annotation: ${anno.getClass.getSimpleName}\n" +
+          s" Please report this issue at https://github.com/ucb-bar/chiseltest/issues"
+      )
+      Some(UnsupportedAnnotation(anno.getClass.getSimpleName, anno.toString))
   }
 
   private def convert(c: Circuit): firrtl2.ir.Circuit =

--- a/src/main/scala/chiseltest/simulator/ChiselBridge.scala
+++ b/src/main/scala/chiseltest/simulator/ChiselBridge.scala
@@ -205,6 +205,7 @@ private object ChiselBridge {
     case AsyncResetType => firrtl2.ir.AsyncResetType
     case AnalogType(w)  => firrtl2.ir.AnalogType(convert(w))
     case UnknownType    => firrtl2.ir.UnknownType
+    case ConstType(tpe) => convert(tpe)
     case BundleType(fields) =>
       firrtl2.ir.BundleType(fields.map { case Field(name, flip, tpe) =>
         firrtl2.ir.Field(name, convert(flip), convert(tpe))

--- a/src/main/scala/chiseltest/simulator/ChiselBridge.scala
+++ b/src/main/scala/chiseltest/simulator/ChiselBridge.scala
@@ -154,7 +154,8 @@ private object ChiselBridge {
     // ignoreDecodeTableAnnotation since it is not needed by the firrtl compiler
     case _: DecodeTableAnnotation => None
     //
-    case _ => throw new NotImplementedError(s"TODO: convert ${anno}")
+    case _ => Some(UnsupportedAnnotation(anno.getClass.getSimpleName, anno.toString))
+    // case _ => throw new NotImplementedError(s"TODO: convert ${anno}")
   }
 
   private def convert(c: Circuit): firrtl2.ir.Circuit =

--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -105,7 +105,7 @@ private object VerilatorSimulator extends Simulator {
     val coverageFile = targetDir / "coverage.dat"
     def readCoverage(): List[(String, Long)] = {
       assert(os.exists(coverageFile), s"Could not find `$coverageFile` file!")
-      VerilatorCoverage.loadCoverage(coverageAnnos, coverageFile)
+      VerilatorCoverage.loadCoverage(coverageAnnos, coverageFile, (majorVersion, minorVersion))
     }
 
     val args = getSimulatorArgs(state)
@@ -152,7 +152,7 @@ private object VerilatorSimulator extends Simulator {
     val coverageFile = targetDir / "coverage.dat"
     def readCoverage(): List[(String, Long)] = {
       assert(os.exists(coverageFile), s"Could not find `$coverageFile` file!")
-      VerilatorCoverage.loadCoverage(coverageAnnos, coverageFile)
+      VerilatorCoverage.loadCoverage(coverageAnnos, coverageFile, (majorVersion, minorVersion))
     }
 
     val args = getSimulatorArgs(state)

--- a/src/main/scala/treadle2/stage/phases/GetFirrtlAst.scala
+++ b/src/main/scala/treadle2/stage/phases/GetFirrtlAst.scala
@@ -38,7 +38,7 @@ object GetFirrtlAst extends Phase {
     def handleFirrtlFile(): Option[AnnotationSeq] = {
       annotationSeq.collectFirst { case FirrtlFileAnnotation(fileName) => fileName } match {
         case Some(fileName) =>
-          val file = io.Source.fromFile(fileName)
+          val file = scala.io.Source.fromFile(fileName)
           val text = file.mkString
           file.close()
 

--- a/src/test/scala/chiseltest/simulator/Verilator.scala
+++ b/src/test/scala/chiseltest/simulator/Verilator.scala
@@ -28,7 +28,7 @@ class VerilatorSpecificTests extends FlatSpecWithTargetDir {
     val (_, out) = CaptureStdout {
       sim.findVersions()
     }
-    assert(out.contains("Found Verilator 4"))
+    assert(out.contains("Found Verilator "))
   }
 
   it should "print out commands and verilator results in debug mode" taggedAs RequiresVerilator in {
@@ -45,8 +45,6 @@ class VerilatorSpecificTests extends FlatSpecWithTargetDir {
     val verilatorBinName = if (JNAUtils.isWindows) { "verilator_bin" }
     else { "verilator" }
     assert(out.contains(s"${verilatorBinName} --cc --exe "))
-    assert(out.contains("g++"))
-    assert(out.contains("perl"))
     assert(out.contains("make -C"))
   }
 }

--- a/src/test/scala/chiseltest/tests/VecPokeExpectTest.scala
+++ b/src/test/scala/chiseltest/tests/VecPokeExpectTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.freespec.AnyFreeSpec
 
 class UsesVec extends Module {
   val in = IO(Input(Vec(4, UInt(5.W))))
-  val addr = IO(Input(UInt(8.W)))
+  val addr = IO(Input(UInt(2.W)))
   val out = IO(Output(UInt(5.W)))
 
   out := in(addr)

--- a/src/test/scala/treadle2/ModuleInLineSpec.scala
+++ b/src/test/scala/treadle2/ModuleInLineSpec.scala
@@ -12,7 +12,7 @@ class ModuleInLineSpec extends AnyFlatSpec with Matchers with LazyLogging {
 
   it should "expand instances as found" in {
     val stream = getClass.getResourceAsStream("/treadle/three_deep.fir")
-    val input = io.Source.fromInputStream(stream).mkString
+    val input = scala.io.Source.fromInputStream(stream).mkString
 
     TreadleTestHarness(Seq(FirrtlSourceAnnotation(input))) { tester =>
       tester.engine.symbolTable.outputPortsNames.size should be > 0
@@ -21,7 +21,7 @@ class ModuleInLineSpec extends AnyFlatSpec with Matchers with LazyLogging {
 
   it should "nester registers should all be using the same clock" in {
     val stream = getClass.getResourceAsStream("/treadle/NestedModsWithReg.fir")
-    val input = io.Source.fromInputStream(stream).mkString
+    val input = scala.io.Source.fromInputStream(stream).mkString
 
     TreadleTestHarness(Seq(FirrtlSourceAnnotation(input))) { tester =>
       def testIt(): Unit = {


### PR DESCRIPTION
Hi,
I'm trying to help with expediating a chiseltest 6.0.0 release as 6.0-SNAPSHOT does not work with the chisel-6.0.0 release.
I also noticed the Verilator coverage support was broken with Verilator versions >= 5.012 (and probably >=5).
Tested only on macOS. All tests (excluding VCS backend, but *including* Verilator, Icarus, and formal) pass. Tests were run as:
`sbt "testOnly chiseltest.** -- -l RequiresVcs"`

Please let me know if any changes are required or otherwise free to make any modifications.

Summary of changes:
- Bumped chisel -> 6.0.0
 - Fixed missing (moved) 'Width' class
- Bumped scala -> 2.13.12
 - Fixed compilation issues due to 'scala.io' namespace clash
- bump sbt -> 1.9.8
- fix Verilator 5.x coverage
- fix Verilator 5.x tests