### PR TITLE
Reintroduce FixedPoint support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "fixedpoint"]
+	path = fixedpoint
+	url = git@github.com:ucb-bar/fixedpoint.git

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,11 @@ lazy val publishSettings = Seq(
   }
 )
 
+lazy val fixedpoint = (project in file("fixedpoint"))
+  .settings(commonSettings)
+
 lazy val chiseltest = (project in file("."))
+  .dependsOn(fixedpoint)
   .settings(commonSettings)
   .settings(chiseltestSettings)
   .settings(publishSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,13 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("2.13.10")
 )
 
-val chiselVersion = "5.0.0"
+val chiselVersion = "5.1.0"
 val firrtlVersion = "5.0.0"
 
 lazy val chiseltestSettings = Seq(
   name := "chiseltest",
   // we keep in sync with chisel version names
-  version := "5.0.2",
+  version := "5.1.0",
   scalacOptions := Seq(
     "-deprecation",
     "-feature",

--- a/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
@@ -16,7 +16,7 @@ class HasOddWidthSInt extends Module {
   out := masked === in
 }
 
-// The poke of a negative number into an SInt input that is not a standard word size
+// The poke of a negative number into an SInt or FixedPoint input that is not a standard word size
 // would break in verilator if the poked value was not masked to the correct number of
 // bits first. This was fixed by masking those values to the proper width before poking
 class NegativeInputValuesTest extends AnyFreeSpec with ChiselScalatestTester {

--- a/src/test/scala/chiseltest/tests/ElementTest.scala
+++ b/src/test/scala/chiseltest/tests/ElementTest.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chiseltest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import fixedpoint._
 
 class ElementTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2 with Element types"
@@ -91,6 +92,64 @@ class ElementTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
       c.io.expect(false.B, false.B, false.B, false.B)
       c.io.expect(true.B, false.B, false.B, true.B)
       c.io.expect(false.B, true.B, false.B, true.B)
+    }
+  }
+
+  it should "work with FixedPoint" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val in1 = Input(FixedPoint(8.W, 2.BP))
+        val in2 = Input(FixedPoint(8.W, 2.BP))
+        val out = Output(FixedPoint(8.W, 2.BP))
+
+        def expect(in1Val: FixedPoint, in2Val: FixedPoint, outVal: FixedPoint): Unit = {
+          in1.poke(in1Val)
+          in2.poke(in2Val)
+          out.expect(outVal)
+        }
+      })
+      io.out := io.in1 + io.in2
+    }) { c =>
+      c.io.expect(0.F(2.BP), 0.F(2.BP), 0.F(2.BP))
+      c.io.expect(1.F(2.BP), 1.F(2.BP), 2.F(2.BP))
+      c.io.expect(0.5.F(2.BP), 0.5.F(2.BP), 1.F(2.BP))
+      c.io.expect(0.5.F(2.BP), -0.5.F(2.BP), 0.F(2.BP))
+
+      // Overflow test, treating it as a 6-bit signed int
+      c.io.expect(31.F(2.BP), 1.F(2.BP), -32.F(2.BP))
+      c.io.expect(-32.F(2.BP), -1.F(2.BP), 31.F(2.BP))
+
+      c.io.expect(31.F(2.BP), 31.F(2.BP), -2.F(2.BP))
+      c.io.expect(-32.F(2.BP), -32.F(2.BP), 0.F(2.BP))
+
+      // Overflow test with decimal component
+      c.io.expect(31.75.F(2.BP), 31.75.F(2.BP), -0.5.F(2.BP))
+      c.io.expect(31.75.F(2.BP), 0.25.F(2.BP), -32.F(2.BP))
+    }
+  }
+
+  it should "peek on FixedPoint correctly" in {
+    test(new PassthroughModule(new Bundle() {
+      val d1 = FixedPoint(64.W, 0.BP)
+      val d2 = FixedPoint(66.W, 2.BP)
+    })) { c =>
+      c.in.d1.poke(BigDecimal(Long.MaxValue).F(0.BP))
+      c.out.d1.peek().litToBigDecimal should be (BigDecimal(Long.MaxValue))
+
+      c.in.d1.poke(BigDecimal(Long.MinValue).F(0.BP))
+      c.out.d1.peek().litToBigDecimal should be (BigDecimal(Long.MinValue))
+
+      c.in.d1.poke(0.F(0.BP))
+      c.out.d1.peek().litToBigDecimal should be (BigDecimal(0))
+
+      c.in.d2.poke(BigDecimal(Long.MaxValue).F(2.BP))
+      c.out.d2.peek().litToBigDecimal should be (BigDecimal(Long.MaxValue))
+
+      c.in.d2.poke(BigDecimal(Long.MinValue).F(2.BP))
+      c.out.d2.peek().litToBigDecimal should be (BigDecimal(Long.MinValue))
+
+      c.in.d2.poke(0.F(2.BP))
+      c.out.d2.peek().litToBigDecimal should be (BigDecimal(0))
     }
   }
 }

--- a/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
+++ b/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
@@ -7,6 +7,7 @@ import chiseltest._
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import fixedpoint._
 
 class FaultDecoderTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
@@ -39,6 +40,26 @@ class FaultDecoderTest extends AnyFlatSpec with ChiselScalatestTester with Match
     }
     exc.getMessage should include ("true (1, 0x1)")
     exc.getMessage should include ("expected=false (0, 0x0)")
+  }
+
+  it should "display decimal for fixedpoint" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule((1.5).F(1.BP))) { c =>
+        c.out.expect((1).F(1.BP))
+      }
+    }
+    exc.getMessage should include ("1.5 (3, 0x3)")
+    exc.getMessage should include ("expected=1.0 (2, 0x2)")
+  }
+
+  it should "display decimal for negative fixedpoint" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule((-2.0).F(1.BP))) { c =>
+        c.out.expect((-0.5).F(1.BP))
+      }
+    }
+    exc.getMessage should include ("-2.0 (-4, -0x4)")
+    exc.getMessage should include ("expected=-0.5 (-1, -0x1)")
   }
 
   ignore should "display names for enums" in {  // needs better reflection support in enums

--- a/src/test/scala/chiseltest/tests/FixedPointTests.scala
+++ b/src/test/scala/chiseltest/tests/FixedPointTests.scala
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.tests
+
+import chisel3._
+import chiseltest._
+import chiseltest.simulator.RequiresVerilator
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.freespec.AnyFreeSpec
+import fixedpoint._
+
+class FixedPointTests extends AnyFreeSpec with ChiselScalatestTester {
+  "fixed point reduce should work with BigDecimal" in {
+    test(new FixedPointReduce(FixedPoint(70.W, 60.BP), 10)) { dut =>
+      val nums = (0 until dut.size).map { _ => 0.1 }
+      nums.zipWithIndex.foreach { case (num, index) =>
+        dut.in(index).poke(num)
+      }
+      dut.clock.step()
+      val _ = dut.sum.peekBigDecimal()
+      dut.sum.expect(BigDecimal("1.000000000000000052041704279304213"))
+    }
+  }
+
+  "fixed point reduce should fail without BigDecimal" in {
+    val e = intercept[ChiselException] {
+      test(new FixedPointReduce(FixedPoint(70.W, 60.BP), 10)) { dut =>
+        val nums = (0 until dut.size).map { _ => 0.1 }
+        nums.zipWithIndex.foreach { case (num, index) =>
+          dut.in(index).poke(num)
+        }
+        dut.clock.step()
+        // The following should generate a ChiselException, losing precision trying to represent a value as a Double.
+        val _ = dut.sum.peekDouble()
+      }
+    }
+    assert(e.getMessage.contains("is too big, precision lost with > 53 bits"))
+  }
+
+  private def testFixedPointDivide(dut: FixedPointDivide): Unit = {
+    for(d <- BigDecimal(0.0) to BigDecimal(15.0) by BigDecimal(1.0 / 3.0)) {
+      dut.in.poke(d.toDouble)
+      dut.clock.step()
+      val _ = dut.out.peekDouble()
+      dut.out.expect(d.toDouble / 4.0)
+    }
+  }
+
+  "with enough bits fixed point pseudo divide should work" in {
+    test(new FixedPointDivide(FixedPoint(64.W, 32.BP), 2))(testFixedPointDivide)
+  }
+
+  "not enough bits and fixed point pseudo divide will not work" in {
+    assertThrows[TestFailedException] {
+      test(new FixedPointDivide(FixedPoint(10.W, 4.BP), 2))(testFixedPointDivide)
+    }
+  }
+
+  private def testFixedIsWhole(dut: FixedIsWhole): Unit = {
+    for(i <- BigDecimal(-2.75) to BigDecimal(1.75) by 0.25) {
+      dut.in.poke(i.toDouble)
+      dut.clock.step()
+      val _ = dut.out.peek()
+      dut.out.expect(i.isWhole)
+    }
+  }
+
+  "FixedPoint width 16 succeeds on verilator" taggedAs RequiresVerilator in {
+    test(new FixedIsWhole(16)).withAnnotations(Seq(VerilatorBackendAnnotation))(testFixedIsWhole)
+  }
+
+  "FixedPoint width 15 succeeds on verilator" taggedAs RequiresVerilator in {
+    test(new FixedIsWhole(15)).withAnnotations(Seq(VerilatorBackendAnnotation))(testFixedIsWhole)
+  }
+
+  "FixedPoint width 15 succeeds on treadle" in {
+    test(new FixedIsWhole(15))(testFixedIsWhole)
+  }
+}
+
+
+/** Regression test which used to fail due to extra high bits being poked. */
+private class FixedIsWhole(w: Int) extends Module {
+  val in = IO(Input(FixedPoint(w.W, 2.BP)))
+  val out = IO(Output(Bool()))
+  val lsbsChopped = in.setBinaryPoint(0)
+  val lsbsZeroed = (lsbsChopped << 2).asFixedPoint(2.BP)
+  out := lsbsZeroed === in
+}
+
+private class FixedPointReduce(fixedType: FixedPoint, val size: Int) extends Module {
+  val in = IO(Input(Vec(size, fixedType)))
+  val sum = IO(Output(fixedType))
+  sum := in.reduce(_ + _)
+}
+
+private class FixedPointDivide(val fixedType: FixedPoint, val shiftAmount: Int) extends Module {
+  val in = IO(Input(fixedType))
+  val out = IO(Output(fixedType))
+  out := (in.asUInt >> shiftAmount).asFixedPoint(fixedType.binaryPoint)
+}
+


### PR DESCRIPTION
https://github.com/ucb-bar/chiseltest/pull/624 removed FixedPoint support because this feature was removed from Chisel5. 

There is some effort to reintroduce FixedPoint support in Chisel (https://github.com/chipsalliance/chisel/issues/3161) through a custom library (https://github.com/ucb-bar/fixedpoint).

This pull request reintroduces FixedPoint support in Chiseltest5 using that fixedpoint library.

---

The main change in this PR are:

* Added `fixedpoint` as a git submodule
* Cherry-picked https://github.com/ucb-bar/chiseltest/pull/687 because that allows easy registering of `fixedpoint` as a subproject
* `git revert d8a44b2`

For this last one, `git revert d8a44b2`, I only reintroduced changes related to `FixedPoint`, not `Interval`.

I have also not included any old `FixedPoint` support that was present in the legacy `PeekPokeTester`. The reason for this is that using `FixedPoint` with `PeekPokeTester` was already integrated by @konda-x1 and @milovanovic into `dsptools` (https://github.com/ucb-bar/dsptools/blob/master/src/main/scala/dsptools/misc/PeekPokeDspExtensions.scala).

---

This is my first pull request for a Scala project, so let me know if there is anything you'd like me to improve :-)