### PR TITLE
[CI] Increase timeout for verilator tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
   verilator:
     name: verilator regressions
     runs-on: ubuntu-20.04
+    timeout-minutes: 600
     strategy:
       matrix:
         # 4.028: Ubuntu 22.04, Fedora 32
@@ -121,6 +122,7 @@ jobs:
           sudo make install
           verilator --version
       - name: Test
+        timeout-minutes: 480
         run: sbt "testOnly chiseltest.** -- -n RequiresVerilator"
 
   formal:


### PR DESCRIPTION
Increase the timeout to prevent fails. At some point though, the number of supported/tested verilator versions should probably be reduced.