### PR TITLE
Add k-induction for SmtModelCheckers 

### DIFF
--- a/src/main/scala/chiseltest/formal/Formal.scala
+++ b/src/main/scala/chiseltest/formal/Formal.scala
@@ -13,6 +13,7 @@ import firrtl2.transforms.formal.DontAssertSubmoduleAssumptionsAnnotation
 
 sealed trait FormalOp extends NoTargetAnnotation
 case class BoundedCheck(kMax: Int = -1) extends FormalOp
+case class InductionCheck(kMax: Int = -1) extends FormalOp
 
 /** Specifies how many cycles the circuit should be reset for. */
 case class ResetOption(cycles: Int = 1) extends NoTargetAnnotation {
@@ -79,5 +80,7 @@ private object Formal {
   def executeOp(state: CircuitState, resetLength: Int, op: FormalOp): Unit = op match {
     case BoundedCheck(kMax) =>
       backends.Maltese.bmc(state.circuit, state.annotations, kMax = kMax, resetLength = resetLength)
+    case InductionCheck(kMax) =>
+      backends.Maltese.induction(state.circuit, state.annotations, kMax = kMax, resetLength = resetLength)
   }
 }

--- a/src/main/scala/chiseltest/formal/Formal.scala
+++ b/src/main/scala/chiseltest/formal/Formal.scala
@@ -28,6 +28,14 @@ private[chiseltest] object FailedBoundedCheckException {
   }
 }
 
+class FailedInductionCheckException(val message: String, val failAt: Int) extends Exception(message)
+private[chiseltest] object FailedInductionCheckException {
+  def apply(module: String, failAt: Int): FailedInductionCheckException = {
+    val msg = s"[$module] found an assertion violation after $failAt steps!"
+    new FailedInductionCheckException(msg, failAt)
+  }
+}
+
 /** Adds the `verify` command for formal checks to a ChiselScalatestTester */
 trait Formal { this: HasTestName =>
   def verify[T <: Module](dutGen: => T, annos: AnnotationSeq, chiselAnnos: firrtl.AnnotationSeq = Seq()): Unit = {

--- a/src/main/scala/chiseltest/formal/backends/IsModelChecker.scala
+++ b/src/main/scala/chiseltest/formal/backends/IsModelChecker.scala
@@ -20,7 +20,7 @@ private[chiseltest] trait IsModelChecker {
   def name: String
   val prefix:        String
   val fileExtension: String
-  def check(sys:          TransitionSystem, kMax:        Int = -1): ModelCheckResult
+  def checkBounded(sys:   TransitionSystem, kMax:        Int = -1): ModelCheckResult
   def checkInduction(sys: TransitionSystem, resetLength: Int, kMax: Int = -1): ModelCheckResult
 }
 

--- a/src/main/scala/chiseltest/formal/backends/IsModelChecker.scala
+++ b/src/main/scala/chiseltest/formal/backends/IsModelChecker.scala
@@ -12,12 +12,16 @@ private[chiseltest] case class ModelCheckSuccess() extends ModelCheckResult { ov
 private[chiseltest] case class ModelCheckFail(witness: Witness) extends ModelCheckResult {
   override def isFail: Boolean = true
 }
+private[chiseltest] case class ModelCheckFailInduction(witness: Witness) extends ModelCheckResult {
+  override def isFail: Boolean = true
+}
 
 private[chiseltest] trait IsModelChecker {
   def name: String
   val prefix:        String
   val fileExtension: String
-  def check(sys: TransitionSystem, kMax: Int = -1): ModelCheckResult
+  def check(sys:          TransitionSystem, kMax:        Int = -1): ModelCheckResult
+  def checkInduction(sys: TransitionSystem, resetLength: Int, kMax: Int = -1): ModelCheckResult
 }
 
 private[chiseltest] case class Witness(

--- a/src/main/scala/chiseltest/formal/backends/Maltese.scala
+++ b/src/main/scala/chiseltest/formal/backends/Maltese.scala
@@ -68,7 +68,8 @@ private[chiseltest] object Maltese {
     require(kMax > 0)
     require(resetLength >= 0)
 
-    val checkFn = (checker: IsModelChecker, sys: TransitionSystem) => checker.check(sys, kMax = kMax + resetLength);
+    val checkFn = (checker: IsModelChecker, sys: TransitionSystem) =>
+      checker.checkBounded(sys, kMax = kMax + resetLength);
     check(circuit, annos, checkFn, resetLength);
   }
 

--- a/src/main/scala/chiseltest/formal/backends/btor/Btor2ModelChecker.scala
+++ b/src/main/scala/chiseltest/formal/backends/btor/Btor2ModelChecker.scala
@@ -14,7 +14,7 @@ class BtormcModelChecker(targetDir: os.Path) extends IsModelChecker {
     throw new RuntimeException(s"Induction unsupported for btormc");
   }
 
-  override def check(sys: TransitionSystem, kMax: Int): ModelCheckResult = {
+  override def checkBounded(sys: TransitionSystem, kMax: Int): ModelCheckResult = {
     // serialize the system to btor2
     val filename = sys.name + ".btor"
     // btromc isn't happy if we include output nodes, so we skip them during serialization

--- a/src/main/scala/chiseltest/formal/backends/btor/Btor2ModelChecker.scala
+++ b/src/main/scala/chiseltest/formal/backends/btor/Btor2ModelChecker.scala
@@ -10,6 +10,10 @@ class BtormcModelChecker(targetDir: os.Path) extends IsModelChecker {
   override val name:   String = "btormc"
   override val prefix: String = "btormc"
 
+  override def checkInduction(sys: TransitionSystem, resetLenght: Int, kMax: Int = -1): ModelCheckResult = {
+    throw new RuntimeException(s"Induction unsupported for btormc");
+  }
+
   override def check(sys: TransitionSystem, kMax: Int): ModelCheckResult = {
     // serialize the system to btor2
     val filename = sys.name + ".btor"

--- a/src/main/scala/chiseltest/formal/backends/smt/CompactSmtEncoding.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/CompactSmtEncoding.scala
@@ -24,10 +24,12 @@ class CompactSmtEncoding(sys: TransitionSystem) extends TransitionSystemSmtEncod
     s
   }
 
-  def init(ctx: SolverContext): Unit = {
+  def init(ctx: SolverContext, isArbitraryStep: Boolean): Unit = {
     assert(states.isEmpty)
     val s0 = appendState(ctx)
-    ctx.assert(BVFunctionCall(stateInitFun, List(s0), 1))
+    if (!isArbitraryStep) {
+      ctx.assert(BVFunctionCall(stateInitFun, List(s0), 1))
+    }
   }
 
   def unroll(ctx: SolverContext): Unit = {

--- a/src/main/scala/chiseltest/formal/backends/smt/SMTModelChecker.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/SMTModelChecker.scala
@@ -24,12 +24,77 @@ class SMTModelChecker(
   override val prefix:        String = solver.name
   override val fileExtension: String = ".smt2"
 
+  override def checkInduction(sys: TransitionSystem, resetLength: Int, kMax: Int = -1): ModelCheckResult = {
+    require(kMax > 0 && kMax <= 2000, s"unreasonable kMax=$kMax")
+    // Check BMC first
+    check(sys, kMax + resetLength) match {
+      case ModelCheckFail(w) => return ModelCheckFail(w)
+      case _                 =>
+    }
+
+    val (ctx, enc) = checkInit(sys)
+
+    // TODO: remove hardcoding of "_resetActive"
+    val constraints = sys.signals.filter(s => s.lbl == IsConstraint && s.name != "_resetActive").map(_.name)
+    val assertions = sys.signals.filter(_.lbl == IsBad).map(_.name)
+
+    (0 to kMax).foreach { k =>
+      // Assume all constraints hold for each k
+      constraints.foreach(c => ctx.assert(enc.getConstraint(c)))
+      // Assume All assertions up to k
+      assertions.foreach(c => ctx.assert(enc.getAssertion(c)))
+      // Advance
+      enc.unroll(ctx)
+    }
+    // Assume constraints one last time
+    constraints.foreach(c => ctx.assert(enc.getConstraint(c)))
+
+    val modelResult =
+      checkAssertions(sys, ctx, enc, assertions, kMax).map(ModelCheckFailInduction(_)).getOrElse(ModelCheckSuccess())
+    checkFini(ctx)
+    modelResult
+  }
+
   override def check(
     sys:  TransitionSystem,
     kMax: Int
   ): ModelCheckResult = {
     require(kMax > 0 && kMax <= 2000, s"unreasonable kMax=$kMax")
 
+    val (ctx, enc) = checkInit(sys)
+
+    val constraints = sys.signals.filter(_.lbl == IsConstraint).map(_.name)
+    val assertions = sys.signals.filter(_.lbl == IsBad).map(_.name)
+
+    (0 to kMax).foreach { k =>
+      if (printProgress) println(s"Step #$k")
+
+      // assume all constraints hold in this step
+      constraints.foreach(c => ctx.assert(enc.getConstraint(c)))
+
+      // make sure the constraints are not contradictory
+      if (options.checkConstraints) {
+        val res = ctx.check(produceModel = false)
+        assert(res.isSat, s"Found unsatisfiable constraints in cycle $k")
+      }
+
+      checkAssertions(sys, ctx, enc, assertions, k) match {
+        case Some(w) => {
+          checkFini(ctx)
+          return ModelCheckFail(w)
+        }
+        case _ => {}
+      }
+      // advance
+      enc.unroll(ctx)
+    }
+
+    checkFini(ctx)
+    ModelCheckSuccess()
+  }
+
+  // Initialise solver context and transition system
+  private def checkInit(sys: TransitionSystem): (SolverContext, TransitionSystemSmtEncoding) = {
     val ctx = solver.createContext()
     // z3 only supports the non-standard as-const array syntax when the logic is set to ALL
     val logic = if (solver.name.contains("z3")) { "ALL" }
@@ -49,71 +114,58 @@ class SMTModelChecker(
     enc.defineHeader(ctx)
     enc.init(ctx)
 
-    val constraints = sys.signals.filter(_.lbl == IsConstraint).map(_.name)
-    val assertions = sys.signals.filter(_.lbl == IsBad).map(_.name)
+    (ctx, enc)
+  }
 
-    (0 to kMax).foreach { k =>
-      if (printProgress) println(s"Step #$k")
-
-      // assume all constraints hold in this step
-      constraints.foreach(c => ctx.assert(enc.getConstraint(c)))
-
-      // make sure the constraints are not contradictory
-      if (options.checkConstraints) {
-        val res = ctx.check(produceModel = false)
-        assert(res.isSat, s"Found unsatisfiable constraints in cycle $k")
-      }
-
-      if (options.checkBadStatesIndividually) {
-        // check each bad state individually
-        assertions.zipWithIndex.foreach { case (b, bi) =>
-          if (printProgress) print(s"- b$bi? ")
-
-          ctx.push()
-          ctx.assert(BVNot(enc.getAssertion(b)))
-          val res = ctx.check(produceModel = false)
-
-          // did we find an assignment for which the bad state is true?
-          if (res.isSat) {
-            if (printProgress) println("❌")
-            val w = getWitness(ctx, sys, enc, k, Seq(b))
-            ctx.pop()
-            ctx.pop()
-            assert(ctx.stackDepth == 0, s"Expected solver stack to be empty, not: ${ctx.stackDepth}")
-            ctx.close()
-            return ModelCheckFail(w)
-          } else {
-            if (printProgress) println("✅")
-          }
-          ctx.pop()
-        }
-      } else {
-        val anyBad = BVNot(BVAnd(assertions.map(enc.getAssertion)))
-        ctx.push()
-        ctx.assert(anyBad)
-        val res = ctx.check(produceModel = false)
-
-        // did we find an assignment for which at least one bad state is true?
-        if (res.isSat) {
-          val w = getWitness(ctx, sys, enc, k)
-          ctx.pop()
-          ctx.pop()
-          assert(ctx.stackDepth == 0, s"Expected solver stack to be empty, not: ${ctx.stackDepth}")
-          ctx.close()
-          return ModelCheckFail(w)
-        }
-        ctx.pop()
-      }
-
-      // advance
-      enc.unroll(ctx)
-    }
-
-    // clean up
+  private def checkFini(ctx: SolverContext) = {
     ctx.pop()
     assert(ctx.stackDepth == 0, s"Expected solver stack to be empty, not: ${ctx.stackDepth}")
     ctx.close()
-    ModelCheckSuccess()
+  }
+
+  // Returns Some(witness) if an assertion failed, otherwise returns  None
+  private def checkAssertions(
+    sys:        TransitionSystem,
+    ctx:        SolverContext,
+    enc:        TransitionSystemSmtEncoding,
+    assertions: List[String],
+    k:          Int
+  ): Option[Witness] = {
+    if (options.checkBadStatesIndividually) {
+      // check each bad state individually
+      assertions.zipWithIndex.foreach { case (b, bi) =>
+        if (printProgress) print(s"- b$bi? ")
+
+        ctx.push()
+        ctx.assert(BVNot(enc.getAssertion(b)))
+        val res = ctx.check(produceModel = false)
+
+        // did we find an assignment for which the bad state is true?
+        if (res.isSat) {
+          if (printProgress) println("❌")
+          val w = getWitness(ctx, sys, enc, k, Seq(b))
+          ctx.pop()
+          return Some(w)
+        } else {
+          if (printProgress) println("✅")
+        }
+        ctx.pop()
+      }
+    } else {
+      val anyBad = BVNot(BVAnd(assertions.map(enc.getAssertion)))
+      ctx.push()
+      ctx.assert(anyBad)
+      val res = ctx.check(produceModel = false)
+
+      // did we find an assignment for which at least one bad state is true?
+      if (res.isSat) {
+        val w = getWitness(ctx, sys, enc, k)
+        ctx.pop()
+        return Some(w)
+      }
+      ctx.pop()
+    }
+    None
   }
 
   private def getWitness(

--- a/src/main/scala/chiseltest/formal/backends/smt/UnrollSmtEncoding.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/UnrollSmtEncoding.scala
@@ -15,14 +15,18 @@ class UnrollSmtEncoding(sys: TransitionSystem) extends TransitionSystemSmtEncodi
     // nothing to do in this encoding
   }
 
-  override def init(ctx: SolverContext): Unit = {
+  override def init(ctx: SolverContext, isArbitraryStep: Boolean): Unit = {
     require(currentStep == -1)
     currentStep = 0
     // declare initial states
     sys.states.foreach { state =>
       state.init match {
         case Some(value) =>
-          ctx.runCommand(DefineFunction(at(state.name, 0), Seq(), signalsAndStatesAt(value, 0)))
+          if (isArbitraryStep) {
+            ctx.runCommand(DeclareFunction(at(state.sym, 0), Seq()))
+          } else {
+            ctx.runCommand(DefineFunction(at(state.name, 0), Seq(), signalsAndStatesAt(value, 0)))
+          }
         case None =>
           ctx.runCommand(DeclareFunction(at(state.sym, 0), Seq()))
       }

--- a/src/test/scala/chiseltest/formal/examples/Counter.scala
+++ b/src/test/scala/chiseltest/formal/examples/Counter.scala
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.formal.examples
+
+import chisel3._
+import chiseltest._
+import chiseltest.formal._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class CounterVerify extends AnyFlatSpec with ChiselScalatestTester with Formal with FormalBackendOption {
+  "Counter" should "succeed BMC" taggedAs FormalTag in {
+    verify(new Counter(65000, 60000), Seq(BoundedCheck(10), DefaultBackend))
+  }
+
+  "Counter" should "Fail induction" taggedAs FormalTag in {
+    verify(new Counter(65000, 50), Seq(InductionCheck(10), DefaultBackend))
+  }
+}
+
+class Counter(to: Int, assert_bound: Int) extends Module {
+  val en = IO(Input(Bool()))
+  val out = IO(Output(UInt(16.W)))
+
+  val cnt = RegInit(0.U(16.W))
+  out := cnt
+  when(en) {
+    when(cnt === to.U) {
+      cnt := 0.U
+    }.otherwise {
+      cnt := cnt + 1.U;
+    }
+  }
+
+  assert(cnt <= assert_bound.U(16.W))
+}

--- a/src/test/scala/chiseltest/formal/examples/Counter.scala
+++ b/src/test/scala/chiseltest/formal/examples/Counter.scala
@@ -7,12 +7,42 @@ import chiseltest.formal._
 import org.scalatest.flatspec.AnyFlatSpec
 
 class CounterVerify extends AnyFlatSpec with ChiselScalatestTester with Formal with FormalBackendOption {
-  "Counter" should "succeed BMC" taggedAs FormalTag in {
-    verify(new Counter(65000, 60000), Seq(BoundedCheck(10), DefaultBackend))
+  "Counter" should "pass BMC" taggedAs FormalTag in {
+    verify(new Counter(65000, 60000), Seq(BoundedCheck(3), DefaultBackend))
   }
 
-  "Counter" should "Fail induction" taggedAs FormalTag in {
-    verify(new Counter(65000, 50), Seq(InductionCheck(10), DefaultBackend))
+  "Counter" should "fail induction" taggedAs FormalTag in {
+    // btormc induction is unsupported
+    DefaultBackend match {
+      case BtormcEngineAnnotation => {}
+      case anno => {
+        val e = intercept[FailedInductionCheckException] {
+          verify(new Counter(65000, 64999), Seq(InductionCheck(1), anno))
+        }
+        assert(e.failAt == 1)
+      }
+    }
+  }
+
+  "Counter" should "pass induction" taggedAs FormalTag in {
+    // btormc induction is unsupported
+    DefaultBackend match {
+      case BtormcEngineAnnotation => {}
+      case anno                   => verify(new Counter(65000, 65000), Seq(InductionCheck(1), anno))
+    }
+  }
+
+  "Counter" should "Fail BMC step of induction" taggedAs FormalTag in {
+    // btormc induction is unsupported
+    DefaultBackend match {
+      case BtormcEngineAnnotation => {}
+      case anno => {
+        val e = intercept[FailedBoundedCheckException] {
+          verify(new Counter(65000, 4), Seq(InductionCheck(8), anno))
+        }
+        assert(e.failAt == 5)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Reused much of the BMC code.
- Perform BMC for cycles [0..k-1]
- Asserted constraints for cycles [n..n + k]
- Asserted assumptions for cycles [n..n + k-1]
- Checked the negation of the assertions for cycle n + k

I think I've done much of the initial work to support k-induction for SmtModelCheckers. I believe I initially said I'd support it for btormc first but I was unable to generate a witness for my counter test I introduced which should fail. I have verified that the counter test creates a reasonable witness.

One thing I'm not too sure on is the filtering out of the  `_resetActive` constraint during the inductive step because it does seem like a reasonable constraint that someone could write them self. That said, if  the constraint were present, the search space would be far too limited. Have I made the correct choice?

There are a few things I'd like to do before this unmarking this as a draft

- [x] Fix TODOs - One being that I filter out the `_resetActive` constraint by hardcoding its name - I don't think this is great. The other is that there is some code that shares common functionality.
- [x] Add additional testing. I believe there are quite a few zipcpu tests/quizzes I can implement

As a final note, this repo has been a joy to work with and thanks for the guidance so far!
