### PR TITLE
Fix invalid PCH error

### DIFF
--- a/src/main/scala/chiseltest/simulator/IcarusSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/IcarusSimulator.scala
@@ -113,7 +113,9 @@ private object IcarusSimulator extends Simulator with LazyLogging {
     val success = ret.exitCode == 0 && os.exists(lib)
     assert(
       success,
-      s"failed to compiler VPI shared library for circuit ${topName} in work dir $compileDir\n" + cmd.mkString(" ")
+      s"failed to compiler VPI shared library for circuit ${topName} in work dir $compileDir\n" + Utils.quoteCmdArgs(
+        cmd
+      )
     )
     lib
   }
@@ -141,7 +143,7 @@ private object IcarusSimulator extends Simulator with LazyLogging {
     val ret = os.proc(cmd).call(cwd = os.pwd, check = false)
 
     val success = ret.exitCode == 0 && os.exists(os.pwd / simBinary)
-    assert(success, s"iverilog command failed on circuit ${topName} in work dir $targetDir\n" + cmd.mkString(" "))
+    assert(success, s"iverilog command failed on circuit ${topName} in work dir $targetDir\n" + Utils.quoteCmdArgs(cmd))
     Seq("vvp", simBinary.toString())
   }
 

--- a/src/main/scala/chiseltest/simulator/Utils.scala
+++ b/src/main/scala/chiseltest/simulator/Utils.scala
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.simulator
+
+object Utils {
+  def quoteCmdArgs(cmd: Seq[String]): String = {
+    cmd.map(arg => if (arg.contains(" ")) s""""$arg"""" else arg).mkString(" ")
+  }
+}

--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -5,6 +5,7 @@ package chiseltest.simulator
 import firrtl2._
 import firrtl2.annotations._
 import chiseltest.simulator.jna._
+import chiseltest.simulator.Utils.quoteCmdArgs
 
 case object VerilatorBackendAnnotation extends SimulatorAnnotation {
   override def getSimulator: Simulator = VerilatorSimulator
@@ -219,7 +220,7 @@ private object VerilatorSimulator extends Simulator {
   private def run(cmd: Seq[String], cwd: os.Path, verbose: Boolean): os.CommandResult = {
     if (verbose) {
       // print the command and pipe the output to stdout
-      println(cmd.mkString(" "))
+      println(quoteCmdArgs(cmd))
       os.proc(cmd)
         .call(cwd = cwd, stdout = os.ProcessOutput.Readlines(println), stderr = os.ProcessOutput.Readlines(println))
     } else {

--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -229,12 +229,11 @@ private object VerilatorSimulator extends Simulator {
   }
 
   private def DefaultCFlags(topName: String) = List(
-    "-O1",
+    "-Os",
     "-DVL_USER_STOP",
     "-DVL_USER_FATAL",
     "-DVL_USER_FINISH", // this is required because we ant to overwrite the vl_finish function!
-    s"-DTOP_TYPE=V$topName",
-    s"-include V$topName.h"
+    s"-DTOP_TYPE=V$topName"
   )
 
   private def DefaultFlags(topName: String, verilatedDir: os.Path, cFlags: Seq[String], ldFlags: Seq[String]) = List(

--- a/src/main/scala/chiseltest/simulator/ipc/IPCSimulatorContext.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/IPCSimulatorContext.scala
@@ -321,7 +321,7 @@ private[chiseltest] class IPCSimulatorContext(
 
   private def start(): Unit = {
     if (verbose)
-      println(s"""STARTING ${cmd.mkString(" ")}""")
+      println(s"""STARTING ${Utils.quoteCmdArgs(cmd)}""")
     mwhile(!recvOutputs) {}
     isRunning = true
   }
@@ -417,7 +417,7 @@ private[chiseltest] class IPCSimulatorContext(
 private object TesterProcess {
   def apply(cmd: Seq[String], logs: ArrayBuffer[String], verbose: Boolean): Process = {
     require(new java.io.File(cmd.head).exists, s"${cmd.head} doesn't exist")
-    val processBuilder = Process(cmd.mkString(" "))
+    val processBuilder = Process(Utils.quoteCmdArgs(cmd))
     // This makes everything written to stderr get added as lines to logs
     val processLogger = ProcessLogger(
       { str => if (verbose) println(str) },


### PR DESCRIPTION
This PR combines:
* https://github.com/ucb-bar/chiseltest/pull/736
* https://github.com/ucb-bar/chiseltest/pull/737

It changes the default `CFLAGS` for Verilator:
* `-O1` changed to `-Os` as it is a default optimization used by Verilator, and using different ones can result in invalid PCH error ([Verilator OPTs](https://github.com/verilator/verilator/blob/master/include/verilated.mk.in#L129-L136)):
  ```
  cc1plus: error: one or more PCH files were found, but they were invalid
  cc1plus: note: use -Winvalid-pch for more information
  <command-line>: fatal error: VMockArrayTestbench__pch.h.fast: No such file or directory
  compilation terminated.
  ```
* `-include V$topName.h` removed, as it should not be used according to https://github.com/verilator/verilator/issues/5244#issuecomment-2219960148

Moreover, PR improves formatting of displayed commands - e.g. values used for `-CFLAGS` are wrapped with quote.